### PR TITLE
improve print method

### DIFF
--- a/docs/guides/concepts.rst
+++ b/docs/guides/concepts.rst
@@ -15,11 +15,12 @@ An AnalysisTree defines *how* analysis is performed. It's a hierarchical structu
 * **Analysis Node**: What computations to perform on each group
 
 .. code-block:: text
+
     Analysis Tree
-    └- Split Node gender: [df.Gender]
-        └- Analysis Node: wage analysis
-            mean_income: mean_income=lambda df: np.mean(df.Income),
-            count: count=lambda df: len(df)
+    └─ Split Node gender: [df.Gender]
+       └─ Analysis Node: wage analysis
+          ├─ mean_income: mean_income=lambda df: np.mean(df.Income),
+          └─ count: count=lambda df: len(df)
 
 
 **DataTree** - The Results
@@ -34,15 +35,15 @@ When you run an AnalysisTree on data, you get a DataTree containing:
 .. code-block:: text
 
    Data Tree
-   Split: df.Gender # SplitDataNode
-   └- F # LvlDataNode
-     analysis: wage analysis # DataNode 
-       └- mean_income: 75000.0
-       └- count: 3
-   └- M # LvlDataNode
-     analysis: wage analysis # DataNode
-       └- mean_income: 55000.0
-       └- count: 3
+   └─ Split: df.Gender
+      ├─ F
+      │  └─ analysis: wage analysis
+      │     ├─ mean_income: 75000.0
+      │     └─ count: 3
+      └─ M
+         └─ analysis: wage analysis
+            ├─ mean_income: 55000.0
+            └─ count: 3
 
 
 Tree Construction Methods

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -49,15 +49,15 @@ Here's a simple example to get you started:
 .. code-block:: text
 
     Data Tree
-    Split: gender
-        └- F
-            analysis: wage analysis
-            └- mean_income: 75000.0
-            └- count: 3
-        └- M
-            analysis: wage analysis
-            └- mean_income: 50000.0
-            └- count: 3
+    └─ Split: gender
+       ├─ F
+       │  └─ analysis: wage analysis
+       │     ├─ mean_income: 75000.0
+       │     └─ count: 3
+       └─ M
+          └─ analysis: wage analysis
+             ├─ mean_income: 50000.0
+             └─ count: 3
 
 
 Understanding the Workflow

--- a/src/pyMyriad/analysis_tree.py
+++ b/src/pyMyriad/analysis_tree.py
@@ -81,10 +81,14 @@ class AnalysisTree(list):
         Returns:
             str: Formatted tree structure showing splits and analyses.
         """
-        ind = 0
-        res = [x.__str__(ind = ind + 2) for x in self]
-        recusive_str = "".join(res)
-        return "Analysis Tree\n" + recusive_str
+        if len(self) == 0:
+            return "Analysis Tree\n"
+        
+        result = ["Analysis Tree\n"]
+        for i, node in enumerate(self):
+            is_last = (i == len(self) - 1)
+            result.append(node.__str__(is_last=is_last, prefix=""))
+        return "".join(result)
 
     def run(self, data: pd.DataFrame, environ: dict = None) -> DataTree:
         """Run the analysis tree on the provided DataFrame.
@@ -412,26 +416,38 @@ class SplitNode(list):
             self.label = label or analysis_to_string(expr)
             self.str = analysis_to_string(expr)
 
-    def __str__(self, ind: int = 0):
+    def __str__(self, ind: int = 0, is_last: bool = True, prefix: str = ""):
         """Return a string representation of the split node.
         
         Args:
-            ind (int): Indentation level for nested display. Defaults to 0.
+            ind (int): Indentation level for nested display. Defaults to 0 (deprecated, use prefix).
+            is_last (bool): Whether this is the last child of its parent. Defaults to True.
+            prefix (str): The prefix string from parent levels. Defaults to "".
             
         Returns:
             str: Formatted representation of the split and its children.
         """
+        # Build the node expression string
         if self.expr is not None:
             res = self.str
         else:
             expr_lst = [f"{k}: {v}" for k,v in self.str.items()]
             res = " -- ".join(expr_lst)
 
-        split_str = (" " * ind) + f"└- Split Node {self.label}: [" + res + "]\n"
-        recusive_lst = [x.__str__(ind = ind + 2) for x in self]
-        recusive_str = "".join(recusive_lst)
-
-        return split_str + recusive_str
+        # Choose connector based on position
+        connector = "└─ " if is_last else "├─ "
+        split_str = prefix + connector + f"Split Node {self.label}: [" + res + "]\n"
+        
+        # Build prefix for children
+        child_prefix = prefix + ("   " if is_last else "│  ")
+        
+        # Process children
+        result = [split_str]
+        for i, child in enumerate(self):
+            child_is_last = (i == len(self) - 1)
+            result.append(child.__str__(is_last=child_is_last, prefix=child_prefix))
+        
+        return "".join(result)
 
     def run(self, data: pd.DataFrame, environ: dict = None, id: str = None, _N: int = None) -> SplitDataNode:
         """Run the split node on the provided DataFrame.
@@ -751,18 +767,33 @@ class AnalysisNode():
         self.label = label
         self.termination = termination
 
-    def __str__(self, ind: int = 0):
+    def __str__(self, ind: int = 0, is_last: bool = True, prefix: str = ""):
         """Return a string representation of the analysis node.
         
         Args:
-            ind (int): Indentation level for nested display. Defaults to 0.
+            ind (int): Indentation level for nested display. Defaults to 0 (deprecated, use prefix).
+            is_last (bool): Whether this is the last child of its parent. Defaults to True.
+            prefix (str): The prefix string from parent levels. Defaults to "".
             
         Returns:
             str: Formatted representation of the analysis and its computations.
         """
-        analysis_lst = [f"{(ind + 4) * ' '}{i}: {j}\n" for i,j in self.analysis_str.items()]
-        analysis_str = (" " * (ind + 0)) + f"└- Analysis Node: {self.label}\n" + "". join(analysis_lst)
-        return analysis_str
+        # Choose connector based on position
+        connector = "└─ " if is_last else "├─ "
+        node_header = prefix + connector + f"Analysis Node: {self.label}\n"
+        
+        # Build prefix for analysis details
+        detail_prefix = prefix + ("   " if is_last else "│  ")
+        
+        # Format analysis details with box-drawing characters
+        analysis_items = list(self.analysis_str.items())
+        analysis_lines = []
+        for i, (key, value) in enumerate(analysis_items):
+            detail_is_last = (i == len(analysis_items) - 1)
+            detail_connector = "└─ " if detail_is_last else "├─ "
+            analysis_lines.append(detail_prefix + detail_connector + f"{key}: {value}\n")
+        
+        return node_header + "".join(analysis_lines)
     
     def run(self, data, environ = None, id: str = None, _N:int = None) -> DataNode:
         """Run the analysis node on the provided DataFrame.
@@ -830,18 +861,33 @@ class CrossAnalysisNode(list):
         self.ref_lvl = ref_lvl
         self.termination = termination
 
-    def __str__(self, ind: int = 0):
+    def __str__(self, ind: int = 0, is_last: bool = True, prefix: str = ""):
         """Return a string representation of the cross-analysis node.
         
         Args:
-            ind (int): Indentation level for nested display. Defaults to 0.
+            ind (int): Indentation level for nested display. Defaults to 0 (deprecated, use prefix).
+            is_last (bool): Whether this is the last child of its parent. Defaults to True.
+            prefix (str): The prefix string from parent levels. Defaults to "".
             
         Returns:
             str: Formatted representation of the cross-analysis and its computations.
         """
-        analysis_lst = [f"{(ind + 4) * ' '}{i}: {j}\n" for i,j in self.analysis_str.items()]
-        analysis_str = (" " * (ind + 0)) + f"└- Cross Analysis Node: {self.label}\n" + "". join(analysis_lst)
-        return analysis_str
+        # Choose connector based on position
+        connector = "└─ " if is_last else "├─ "
+        node_header = prefix + connector + f"Cross Analysis Node: {self.label}\n"
+        
+        # Build prefix for analysis details
+        detail_prefix = prefix + ("   " if is_last else "│  ")
+        
+        # Format analysis details with box-drawing characters
+        analysis_items = list(self.analysis_str.items())
+        analysis_lines = []
+        for i, (key, value) in enumerate(analysis_items):
+            detail_is_last = (i == len(analysis_items) - 1)
+            detail_connector = "└─ " if detail_is_last else "├─ "
+            analysis_lines.append(detail_prefix + detail_connector + f"{key}: {value}\n")
+        
+        return node_header + "".join(analysis_lines)
     
     def run(self, data: dict, environ = None, id: str = None, _N:int = None) -> DataNode:
         """Run the cross-analysis node on the provided DataFrames.

--- a/src/pyMyriad/data_tree.py
+++ b/src/pyMyriad/data_tree.py
@@ -64,17 +64,33 @@ class DataNode():
         self.depth = depth
         self._N = _N
 
-    def __str__(self, ind: int = 0):
+    def __str__(self, ind: int = 0, is_last: bool = True, prefix: str = ""):
         """Return a string representation of the data node.
         
         Args:
-            ind (int): Indentation level for nested display. Defaults to 0.
+            ind (int): Indentation level for nested display. Defaults to 0 (deprecated, use prefix).
+            is_last (bool): Whether this is the last child of its parent. Defaults to True.
+            prefix (str): The prefix string from parent levels. Defaults to "".
             
         Returns:
             str: Formatted representation of the node's summary statistics.
         """
-        res = [f"{' ' * (ind * 2)}  └- {k}: {str(v)}\n" for k,v in (self.summary or {}).items()]
-        return f"{' ' * (ind * 2)}  analysis: {self.label}\n" + "".join(res)
+        # Choose connector based on position
+        connector = "└─ " if is_last else "├─ "
+        node_header = prefix + connector + f"analysis: {self.label}\n"
+        
+        # Build prefix for analysis details
+        detail_prefix = prefix + ("   " if is_last else "│  ")
+        
+        # Format analysis details with box-drawing characters
+        summary_items = list((self.summary or {}).items())
+        summary_lines = []
+        for i, (key, value) in enumerate(summary_items):
+            detail_is_last = (i == len(summary_items) - 1)
+            detail_connector = "└─ " if detail_is_last else "├─ "
+            summary_lines.append(detail_prefix + detail_connector + f"{key}: {str(value)}\n")
+        
+        return node_header + "".join(summary_lines)
     
     def __flatten__(self, path = (), depth: int = 0, pivot_var = (), pivot_now: bool = False, path_pivot = (), pivot_split = (), pivot_lvl = (), data:bool = False) -> pd.DataFrame:
 
@@ -128,18 +144,31 @@ class SplitDataNode(dict):
         self.split_var = split_var
         self.label = label or analysis_to_string(split_var)
 
-    def __str__(self, ind: int = 0):
+    def __str__(self, ind: int = 0, is_last: bool = True, prefix: str = ""):
         """Return a string representation of the split data node.
         
         Args:
-            ind (int): Indentation level for nested display. Defaults to 0.
+            ind (int): Indentation level for nested display. Defaults to 0 (deprecated, use prefix).
+            is_last (bool): Whether this is the last child of its parent. Defaults to True.
+            prefix (str): The prefix string from parent levels. Defaults to "".
             
         Returns:
             str: Formatted representation of the split and its levels.
         """
-        res = [x.__str__(ind = ind + 1) for x in self.values()]
-        recusive_str = "".join(res)
-        return f"{' ' * (ind * 2)}Split: {self.label}\n" + recusive_str
+        # Choose connector based on position
+        connector = "└─ " if is_last else "├─ "
+        split_str = prefix + connector + f"Split: {self.label}\n"
+        
+        # Build prefix for children
+        child_prefix = prefix + ("   " if is_last else "│  ")
+        
+        # Process children
+        result = [split_str]
+        for i, child in enumerate(self.values()):
+            child_is_last = (i == len(self) - 1)
+            result.append(child.__str__(is_last=child_is_last, prefix=child_prefix))
+        
+        return "".join(result)
     
     def __flatten__(self, path = (), depth: int = 0, pivot_var = (), path_pivot = (), pivot_split = (), pivot_lvl = (), data:bool = False) -> pd.DataFrame:
 
@@ -206,19 +235,31 @@ class LvlDataNode(dict):
         self.meta = meta
         self._N = _N
 
-    def __str__(self, ind: int = 0):
+    def __str__(self, ind: int = 0, is_last: bool = True, prefix: str = ""):
         """Return a string representation of the level data node.
         
         Args:
-            ind (int): Indentation level for nested display. Defaults to 0.
+            ind (int): Indentation level for nested display. Defaults to 0 (deprecated, use prefix).
+            is_last (bool): Whether this is the last child of its parent. Defaults to True.
+            prefix (str): The prefix string from parent levels. Defaults to "".
             
         Returns:
             str: Formatted representation of the level and its children.
         """
-        res = [x.__str__(ind = ind + 1) for x in self.values()]
-        recusive_str = "".join(res)
+        # Choose connector based on position
+        connector = "└─ " if is_last else "├─ "
+        level_str = prefix + connector + f"{self.split_lvl}\n"
         
-        return f"{' ' * (ind * 2)}└- {self.split_lvl}\n" + recusive_str
+        # Build prefix for children
+        child_prefix = prefix + ("   " if is_last else "│  ")
+        
+        # Process children
+        result = [level_str]
+        for i, child in enumerate(self.values()):
+            child_is_last = (i == len(self) - 1)
+            result.append(child.__str__(is_last=child_is_last, prefix=child_prefix))
+        
+        return "".join(result)
     
     def __flatten__(self, path = (), depth:int = 0, pivot_var = (), pivot_now: bool = False, path_pivot = (), pivot_split = (), pivot_lvl = (), data:bool = False) -> pd.DataFrame:
         """Flatten a LvlDataNode
@@ -286,10 +327,14 @@ class DataTree(dict):
         Returns:
             str: Formatted tree structure showing splits, levels, and results.
         """
-        ind = 0
-        res = [x.__str__(ind = ind + 1) for x in self.values()]
-        recusive_str = "".join(res)
-        return "Data Tree\n" + recusive_str
+        if len(self) == 0:
+            return "Data Tree\n"
+        
+        result = ["Data Tree\n"]
+        for i, node in enumerate(self.values()):
+            is_last = (i == len(self) - 1)
+            result.append(node.__str__(is_last=is_last, prefix=""))
+        return "".join(result)
     
     def __flatten__(self, pivot:str = (), data:bool = False) -> pd.DataFrame:
         """Flatten a DataTree into a DataFrame.

--- a/tests/test_data_tree.py
+++ b/tests/test_data_tree.py
@@ -13,7 +13,7 @@ def test_data_node():
     assert dn.summary == {"mean": 2}
     assert dn.label == "MyData"
     assert dn.depth == 1
-    assert str(dn) == '  analysis: MyData\n  └- mean: 2\n'
+    assert str(dn) == '└─ analysis: MyData\n   └─ mean: 2\n'
 
 
 def test_lvl_data_node():
@@ -27,7 +27,7 @@ def test_lvl_data_node():
     assert len(ldn) == 2
     assert "dn1" in ldn
     assert "dn2" in ldn
-    assert str(ldn) == '└- Level1\n    analysis: MyData1\n    └- mean: 2\n    analysis: MyData2\n    └- mean: 5\n'
+    assert str(ldn) == '└─ Level1\n   ├─ analysis: MyData1\n   │  └─ mean: 2\n   └─ analysis: MyData2\n      └─ mean: 5\n'
 
 def test_split_data_node():
     dn1 = DataNode(data = [1,2,3], summary = {"mean": 2}, label = "MyData1", depth = 1)
@@ -39,4 +39,4 @@ def test_split_data_node():
     assert sdn.split_var == "Var1"
     assert len(sdn) == 1
     assert "T" in sdn
-    assert str(sdn) == 'Split: Var1\n  └- Level1\n      analysis: MyData1\n      └- mean: 2\n      analysis: MyData2\n      └- mean: 5\n'
+    assert str(sdn) == '└─ Split: Var1\n   └─ Level1\n      ├─ analysis: MyData1\n      │  └─ mean: 2\n      └─ analysis: MyData2\n         └─ mean: 5\n'


### PR DESCRIPTION
This pull request improves the string representations of analysis and data tree structures to use box-drawing characters for clearer, more visually structured output. It updates both the implementation and documentation to reflect these changes, and adjusts related tests to match the new formatting.

Formatting and visualization improvements:

* Refactored all `__str__` methods in `analysis_tree.py` and `data_tree.py` to use box-drawing characters (e.g., `├─`, `└─`, `│`) for tree visualization, replacing the previous indentation-based approach. This provides clearer, more readable hierarchical output. [[1]](diffhunk://#diff-83244ae0229a31c74b1be17249cb087fa74fcf52efba5814a9a5b177bf60e0c4L84-R91) [[2]](diffhunk://#diff-83244ae0229a31c74b1be17249cb087fa74fcf52efba5814a9a5b177bf60e0c4L415-R450) [[3]](diffhunk://#diff-83244ae0229a31c74b1be17249cb087fa74fcf52efba5814a9a5b177bf60e0c4L754-R796) [[4]](diffhunk://#diff-83244ae0229a31c74b1be17249cb087fa74fcf52efba5814a9a5b177bf60e0c4L833-R890) [[5]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3L67-R93) [[6]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3L131-R171) [[7]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3L209-R262) [[8]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3L289-R337)

Documentation updates:

* Updated example trees in `docs/guides/concepts.rst` and `docs/guides/quickstart.rst` to match the new box-drawing character format, ensuring consistency between documentation and output. [[1]](diffhunk://#diff-969a7b47b249c2fd492bc2f373fee071bfcb43f6f0a2751f67130daed10a0d4dR18-R23) [[2]](diffhunk://#diff-969a7b47b249c2fd492bc2f373fee071bfcb43f6f0a2751f67130daed10a0d4dL37-R46) [[3]](diffhunk://#diff-50f1af4564124ad7ee48686f52995e934bf33ec158b13d0a8d93d3c4613c5c6eL52-R60)

Testing adjustments:

* Modified tests in `tests/test_data_tree.py` to assert against the new string output format, ensuring test coverage for the updated visualization. [[1]](diffhunk://#diff-913b7b4b75352927bdc3f329123792c8be06a53da352bdefa29811defe25a855L16-R16) [[2]](diffhunk://#diff-913b7b4b75352927bdc3f329123792c8be06a53da352bdefa29811defe25a855L30-R30) [[3]](diffhunk://#diff-913b7b4b75352927bdc3f329123792c8be06a53da352bdefa29811defe25a855L42-R42)