### PR TITLE
to json

### DIFF
--- a/docs/guides/interoperability.rst
+++ b/docs/guides/interoperability.rst
@@ -320,9 +320,240 @@ A typical agent interaction looks like this:
    print(result)
 
 
+Exporting Results to JSON
+--------------------------
+
+In addition to serializing the *analysis plan*, you can serialize the
+*results* — the :class:`~pyMyriad.data_tree.DataTree` produced by
+:meth:`~pyMyriad.analysis_tree.AnalysisTree.run` — so that computed
+statistics can be shared with LLM agents or other downstream tools.
+
+Why export results?
+~~~~~~~~~~~~~~~~~~~
+
+An LLM agent working with your analysis may need to:
+
+* **Interpret** computed statistics in natural language.
+* **Compare** results across runs or datasets.
+* **Route** downstream actions based on specific values (e.g. flag anomalies).
+* **Store** results alongside the plan for reproducibility.
+
+Basic usage
+~~~~~~~~~~~
+
+Call :meth:`~pyMyriad.data_tree.DataTree.to_json` on the result returned by
+:meth:`~pyMyriad.analysis_tree.AnalysisTree.run`:
+
+.. code-block:: python
+
+   import numpy as np
+   import pandas as pd
+   from pyMyriad import AnalysisTree
+
+   df = pd.DataFrame({
+       "Gender": ["M", "F", "M", "F", "M", "F"],
+       "Income": [55000, 72000, 48000, 81000, 60000, 67000],
+   })
+
+   tree = (AnalysisTree()
+       .split_by("df.Gender", label="Gender")
+       .analyze_by(
+           n=lambda df: len(df),
+           mean_income=lambda df: np.mean(df.Income),
+           label="stats",
+       ))
+
+   result = tree.run(df, environ={"np": np})
+   json_str = result.to_json()
+   print(json_str)
+
+The output is a compact, hierarchical JSON document:
+
+.. code-block:: json
+
+   {
+     "type": "DataTree",
+     "_N": null,
+     "children": {
+       "Gender": {
+         "type": "SplitDataNode",
+         "split_var": "df.Gender",
+         "label": "Gender",
+         "children": {
+           "F": {
+             "type": "LvlDataNode",
+             "split_lvl": "F",
+             "_N": null,
+             "children": {
+               "stats": {
+                 "type": "DataNode",
+                 "label": "stats",
+                 "_N": null,
+                 "summary": {
+                   "n": 3,
+                   "mean_income": 73333.333
+                 }
+               }
+             }
+           },
+           "M": {
+             "type": "LvlDataNode",
+             "split_lvl": "M",
+             "_N": null,
+             "children": {
+               "stats": {
+                 "type": "DataNode",
+                 "label": "stats",
+                 "_N": null,
+                 "summary": {
+                   "n": 3,
+                   "mean_income": 54333.333
+                 }
+               }
+             }
+           }
+         }
+       }
+     }
+   }
+
+Writing directly to a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pass a file path to write the results at the same time:
+
+.. code-block:: python
+
+   result.to_json("analysis_results.json")
+
+The method always returns the JSON string regardless.
+
+
+JSON structure reference
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The result JSON mirrors the four tree node types.
+
+**DataTree** (root)
+
+.. code-block:: json
+
+   {
+     "type": "DataTree",
+     "_N": null,
+     "children": { ... }
+   }
+
+``_N`` is ``null`` unless a denominator was set on the
+:class:`~pyMyriad.analysis_tree.AnalysisTree` (see
+:meth:`~pyMyriad.analysis_tree.AnalysisTree.__init__`).
+
+**SplitDataNode**
+
+.. code-block:: json
+
+   {
+     "type": "SplitDataNode",
+     "split_var": "df.Gender",
+     "label": "Gender",
+     "children": { ... }
+   }
+
+**LvlDataNode**
+
+.. code-block:: json
+
+   {
+     "type": "LvlDataNode",
+     "split_lvl": "F",
+     "_N": null,
+     "children": { ... }
+   }
+
+**DataNode** (leaf)
+
+.. code-block:: json
+
+   {
+     "type": "DataNode",
+     "label": "stats",
+     "_N": null,
+     "summary": {
+       "n": 3,
+       "mean_income": 73333.333
+     }
+   }
+
+Only the ``summary`` dictionary is exported. The raw ``data`` attribute
+(the underlying :class:`pandas.DataFrame`) is intentionally excluded to keep
+output compact and suitable for LLM context windows.
+
+
+Special value handling
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Input value
+     - JSON output
+   * - ``float("nan")``, ``numpy.nan``
+     - ``"NaN"`` (string)
+   * - ``float("inf")``, ``numpy.inf``
+     - ``"Infinity"`` (string)
+   * - ``float("-inf")``, ``-numpy.inf``
+     - ``"-Infinity"`` (string)
+   * - ``numpy.int64``, ``numpy.float64``
+     - Native Python ``int`` / ``float``
+   * - Other non-serializable objects
+     - ``str(val)`` fallback
+
+This ensures the JSON is always valid and that LLM agents receive a
+human-readable representation of edge-case values.
+
+
+Combined plan + results workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Share both the analysis *plan* and *results* with an LLM agent in a single
+call:
+
+.. code-block:: python
+
+   import json
+   import numpy as np
+   import pandas as pd
+   from pyMyriad import AnalysisTree
+
+   df = pd.DataFrame({
+       "Treatment": ["Drug", "Placebo"] * 50,
+       "Outcome": [10.5, 8.2] * 50,
+   })
+
+   tree = (AnalysisTree()
+       .split_by("df.Treatment", label="Treatment")
+       .analyze_by(
+           n=lambda df: len(df),
+           mean_outcome=lambda df: np.mean(df.Outcome),
+           label="outcomes",
+       ))
+
+   AnalysisTree.set_default_environ({"np": np})
+   result = tree.run(df)
+
+   payload = {
+       "plan": json.loads(tree.to_json()),
+       "results": json.loads(result.to_json()),
+   }
+   # payload can now be passed directly to an LLM agent
+
+
 See Also
 --------
 
 * :doc:`concepts` — understanding the tree structure
 * :doc:`workflows` — common analysis patterns
 * :class:`~pyMyriad.analysis_tree.AnalysisTree` — full API reference
+* :class:`~pyMyriad.data_tree.DataTree` — result tree API reference
+

--- a/src/pyMyriad/data_tree.py
+++ b/src/pyMyriad/data_tree.py
@@ -32,8 +32,60 @@ See also:
     - listing.py: Table generation from DataTree
 """
 
+import json
+import math
+import os
+
 import pandas as pd
+
 from .utils import analysis_to_string
+
+
+def _serialize_summary_value(val):
+    """Convert a summary value to a JSON-safe Python type.
+
+    Rules:
+    - ``None``, ``bool``, ``str`` are returned unchanged.
+    - ``int`` is returned unchanged.
+    - ``float`` is returned unchanged, **except** NaN and ±infinity which
+      become the strings ``"NaN"``, ``"Infinity"``, and ``"-Infinity"``.
+    - Numeric-like objects (e.g. ``numpy.int64``, ``numpy.float64``) are
+      coerced to the corresponding native Python ``int`` or ``float``; the
+      same NaN/infinity rule is then applied to coerced floats.
+    - Everything else is converted via ``str(val)``.
+
+    Args:
+        val: The value to serialize.
+
+    Returns:
+        A JSON-serializable Python object.
+    """
+    if val is None or isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val
+    if isinstance(val, int):
+        return val
+    if isinstance(val, float):
+        if math.isnan(val):
+            return "NaN"
+        if math.isinf(val):
+            return "Infinity" if val > 0 else "-Infinity"
+        return val
+    # Attempt numeric coercion (handles numpy scalars, etc.)
+    try:
+        float_val = float(val)
+        if math.isnan(float_val):
+            return "NaN"
+        if math.isinf(float_val):
+            return "Infinity" if float_val > 0 else "-Infinity"
+        # Preserve integer semantics for whole numbers
+        int_val = int(val)
+        if float_val == int_val:
+            return int_val
+        return float_val
+    except (TypeError, ValueError, OverflowError):
+        return str(val)
 
 
 class DataNode:
@@ -102,6 +154,29 @@ class DataNode:
             )
 
         return node_header + "".join(summary_lines)
+
+    def to_dict(self) -> dict:
+        """Serialize this node to a JSON-compatible dictionary.
+
+        Only the ``summary`` is included (not the raw ``data`` attribute).
+        Non-finite floats become string representations (``"NaN"``,
+        ``"Infinity"``, ``"-Infinity"``).  Other non-serializable values
+        are converted via :func:`str`.
+
+        Returns:
+            dict: A JSON-serializable representation of this node.
+
+        See Also:
+            DataTree.to_json : Serialize the full result tree to JSON.
+        """
+        return {
+            "type": "DataNode",
+            "label": self.label,
+            "_N": self._N,
+            "summary": {
+                k: _serialize_summary_value(v) for k, v in (self.summary or {}).items()
+            },
+        }
 
     def __flatten__(
         self,
@@ -193,6 +268,23 @@ class SplitDataNode(dict):
             result.append(child.__str__(is_last=child_is_last, prefix=child_prefix))
 
         return "".join(result)
+
+    def to_dict(self) -> dict:
+        """Serialize this split node to a JSON-compatible dictionary.
+
+        Returns:
+            dict: A JSON-serializable representation of this node with keys
+            ``type``, ``split_var``, ``label``, and ``children``.
+
+        See Also:
+            DataTree.to_json : Serialize the full result tree to JSON.
+        """
+        return {
+            "type": "SplitDataNode",
+            "split_var": self.split_var,
+            "label": self.label,
+            "children": {k: v.to_dict() for k, v in self.items()},
+        }
 
     def __flatten__(
         self,
@@ -314,6 +406,23 @@ class LvlDataNode(dict):
 
         return "".join(result)
 
+    def to_dict(self) -> dict:
+        """Serialize this level node to a JSON-compatible dictionary.
+
+        Returns:
+            dict: A JSON-serializable representation of this node with keys
+            ``type``, ``split_lvl``, ``_N``, and ``children``.
+
+        See Also:
+            DataTree.to_json : Serialize the full result tree to JSON.
+        """
+        return {
+            "type": "LvlDataNode",
+            "split_lvl": self.split_lvl,
+            "_N": self._N,
+            "children": {k: v.to_dict() for k, v in self.items()},
+        }
+
     def __flatten__(
         self,
         path=(),
@@ -416,6 +525,78 @@ class DataTree(dict):
             is_last = i == len(self) - 1
             result.append(node.__str__(is_last=is_last, prefix=""))
         return "".join(result)
+
+    def to_dict(self) -> dict:
+        """Serialize the result tree to a JSON-compatible dictionary.
+
+        The dictionary captures the full hierarchical result structure,
+        including every split, level, and analysis node with its computed
+        summary statistics.  Raw data (``DataNode.data``) is intentionally
+        excluded to keep the output concise and suitable for LLM consumption.
+
+        Non-finite float values in any summary dictionary are converted to
+        string representations (``"NaN"``, ``"Infinity"``, ``"-Infinity"``).
+        Other non-serializable objects are converted via :func:`str`.
+
+        Returns:
+            dict: A JSON-serializable representation of the result tree with
+            keys ``type``, ``_N``, and ``children``.
+
+        See Also:
+            to_json : Serialize to a JSON string (optionally writing to a file).
+
+        Examples:
+            >>> import numpy as np, pandas as pd
+            >>> from pyMyriad import AnalysisTree
+            >>> df = pd.DataFrame({"A": [1, 2, 3], "G": ["M", "F", "M"]})
+            >>> result = AnalysisTree().split_by("df.G").analyze_by(n="len(df)").run(df, environ={"np": np})
+            >>> d = result.to_dict()
+            >>> d["type"]
+            'DataTree'
+        """
+        return {
+            "type": "DataTree",
+            "_N": self._N,
+            "children": {k: v.to_dict() for k, v in self.items()},
+        }
+
+    def to_json(self, path: str = None, indent: int = 2) -> str:
+        """Serialize the result tree to a JSON string.
+
+        Produces a human-readable JSON representation of all analysis
+        results, suitable for sharing with LLM agents or storing alongside
+        an analysis plan.  The JSON structure mirrors the tree hierarchy:
+        splits, levels, and analysis nodes with their computed statistics.
+
+        Args:
+            path (str, optional): If provided, the JSON is also written to
+                this file.  The directory must already exist.
+                Defaults to ``None``.
+            indent (int, optional): Number of spaces used for indentation.
+                Defaults to ``2``.
+
+        Returns:
+            str: The JSON string representation of the result tree.
+
+        See Also:
+            to_dict : Serialize to a plain Python dictionary.
+            AnalysisTree.to_json : Serialize the *analysis plan* (not results).
+
+        Examples:
+            >>> import numpy as np, pandas as pd
+            >>> from pyMyriad import AnalysisTree
+            >>> df = pd.DataFrame({"A": [1, 2, 3], "G": ["M", "F", "M"]})
+            >>> result = AnalysisTree().split_by("df.G").analyze_by(n="len(df)").run(df, environ={"np": np})
+            >>> json_str = result.to_json()
+            >>> import json; parsed = json.loads(json_str)
+            >>> parsed["type"]
+            'DataTree'
+        """
+        result = json.dumps(self.to_dict(), indent=indent)
+        if path is not None:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(result)
+        return result
 
     def __flatten__(self, pivot: str = (), data: bool = False) -> pd.DataFrame:
         """Flatten a DataTree into a DataFrame.

--- a/src/pyMyriad/data_tree.py
+++ b/src/pyMyriad/data_tree.py
@@ -34,7 +34,6 @@ See also:
 
 import json
 import math
-import os
 
 import pandas as pd
 

--- a/tests/test_data_tree.py
+++ b/tests/test_data_tree.py
@@ -1,5 +1,4 @@
 import json
-import math
 import tempfile
 
 import numpy as np

--- a/tests/test_data_tree.py
+++ b/tests/test_data_tree.py
@@ -1,4 +1,13 @@
-from pyMyriad import DataTree, DataNode, LvlDataNode, SplitDataNode
+import json
+import math
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyMyriad import AnalysisTree, DataTree, DataNode, LvlDataNode, SplitDataNode
+from pyMyriad.data_tree import _serialize_summary_value
 
 
 def test_data_tree_empty():
@@ -71,3 +80,300 @@ def test_data_tree_with_N_list():
     sdn = SplitDataNode(split_var="Var", A=ldn)
     dt = DataTree(_N=[4], Var=sdn)
     assert dt._N == [4]
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_none():
+    assert _serialize_summary_value(None) is None
+
+
+def test_serialize_bool():
+    assert _serialize_summary_value(True) is True
+    assert _serialize_summary_value(False) is False
+
+
+def test_serialize_str():
+    assert _serialize_summary_value("hello") == "hello"
+
+
+def test_serialize_int():
+    assert _serialize_summary_value(42) == 42
+    assert isinstance(_serialize_summary_value(42), int)
+
+
+def test_serialize_float():
+    assert _serialize_summary_value(3.14) == pytest.approx(3.14)
+
+
+def test_serialize_nan():
+    assert _serialize_summary_value(float("nan")) == "NaN"
+
+
+def test_serialize_inf():
+    assert _serialize_summary_value(float("inf")) == "Infinity"
+    assert _serialize_summary_value(float("-inf")) == "-Infinity"
+
+
+def test_serialize_numpy_int():
+    val = np.int64(7)
+    result = _serialize_summary_value(val)
+    assert result == 7
+    assert isinstance(result, int)
+
+
+def test_serialize_numpy_float():
+    val = np.float64(2.5)
+    result = _serialize_summary_value(val)
+    assert result == pytest.approx(2.5)
+    assert isinstance(result, float)
+
+
+def test_serialize_numpy_nan():
+    assert _serialize_summary_value(np.float64("nan")) == "NaN"
+
+
+def test_serialize_numpy_inf():
+    assert _serialize_summary_value(np.float64("inf")) == "Infinity"
+    assert _serialize_summary_value(np.float64("-inf")) == "-Infinity"
+
+
+def test_serialize_numpy_array_falls_back_to_str():
+    arr = np.array([1, 2, 3])
+    result = _serialize_summary_value(arr)
+    assert isinstance(result, str)
+    assert "1" in result
+
+
+# ---------------------------------------------------------------------------
+# DataNode.to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_data_node_to_dict_basic():
+    dn = DataNode(data=[1, 2, 3], summary={"mean": 2.0, "n": 3}, label="stats", depth=1)
+    d = dn.to_dict()
+    assert d["type"] == "DataNode"
+    assert d["label"] == "stats"
+    assert d["summary"]["mean"] == pytest.approx(2.0)
+    assert d["summary"]["n"] == 3
+    assert d["_N"] is None
+
+
+def test_data_node_to_dict_with_N():
+    dn = DataNode(data=None, summary={"n": 1}, label="L", _N=[10, 5])
+    d = dn.to_dict()
+    assert d["_N"] == [10, 5]
+
+
+def test_data_node_to_dict_nan_inf():
+    dn = DataNode(
+        data=None,
+        summary={
+            "nan_val": float("nan"),
+            "inf_val": float("inf"),
+            "ninf_val": float("-inf"),
+        },
+        label="edge",
+    )
+    d = dn.to_dict()
+    assert d["summary"]["nan_val"] == "NaN"
+    assert d["summary"]["inf_val"] == "Infinity"
+    assert d["summary"]["ninf_val"] == "-Infinity"
+
+
+def test_data_node_to_dict_numpy_scalar():
+    dn = DataNode(
+        data=None,
+        summary={"mean": np.float64(3.5), "count": np.int64(4)},
+        label="np",
+    )
+    d = dn.to_dict()
+    # Must be JSON-serializable
+    json.dumps(d)
+    assert d["summary"]["mean"] == pytest.approx(3.5)
+    assert d["summary"]["count"] == 4
+
+
+def test_data_node_to_dict_empty_summary():
+    dn = DataNode(data=None, summary={}, label="empty")
+    d = dn.to_dict()
+    assert d["summary"] == {}
+
+
+def test_data_node_to_dict_none_summary():
+    dn = DataNode(data=None, summary=None, label="no_summary")
+    d = dn.to_dict()
+    assert d["summary"] == {}
+
+
+# ---------------------------------------------------------------------------
+# SplitDataNode.to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_split_data_node_to_dict():
+    dn = DataNode(data=None, summary={"n": 3}, label="stats")
+    ldn = LvlDataNode(stats=dn, split_lvl="Male")
+    sdn = SplitDataNode(split_var="df.Gender", Male=ldn)
+    d = sdn.to_dict()
+    assert d["type"] == "SplitDataNode"
+    assert d["split_var"] == "df.Gender"
+    assert "label" in d
+    assert "Male" in d["children"]
+    assert d["children"]["Male"]["type"] == "LvlDataNode"
+
+
+# ---------------------------------------------------------------------------
+# LvlDataNode.to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_lvl_data_node_to_dict():
+    dn = DataNode(data=None, summary={"n": 2}, label="stats")
+    ldn = LvlDataNode(stats=dn, split_lvl="Female", _N=[10, 4])
+    d = ldn.to_dict()
+    assert d["type"] == "LvlDataNode"
+    assert d["split_lvl"] == "Female"
+    assert d["_N"] == [10, 4]
+    assert "stats" in d["children"]
+    assert d["children"]["stats"]["type"] == "DataNode"
+
+
+# ---------------------------------------------------------------------------
+# DataTree.to_dict / to_json
+# ---------------------------------------------------------------------------
+
+
+def test_data_tree_to_dict_empty():
+    dt = DataTree()
+    d = dt.to_dict()
+    assert d == {"type": "DataTree", "_N": None, "children": {}}
+
+
+def test_data_tree_to_dict_with_N():
+    dn = DataNode(data=None, summary={"n": 1}, label="L")
+    ldn = LvlDataNode(dn=dn, split_lvl="A")
+    sdn = SplitDataNode(split_var="Var", A=ldn)
+    dt = DataTree(_N=[5], Var=sdn)
+    d = dt.to_dict()
+    assert d["_N"] == [5]
+    assert "Var" in d["children"]
+
+
+def test_data_tree_to_json_returns_valid_json():
+    dn = DataNode(data=None, summary={"mean": 4.2}, label="stats")
+    ldn = LvlDataNode(stats=dn, split_lvl="A")
+    sdn = SplitDataNode(split_var="Grp", A=ldn)
+    dt = DataTree(Grp=sdn)
+    json_str = dt.to_json()
+    parsed = json.loads(json_str)
+    assert parsed["type"] == "DataTree"
+    assert parsed["children"]["Grp"]["type"] == "SplitDataNode"
+
+
+def test_data_tree_to_json_writes_file():
+    dn = DataNode(data=None, summary={"n": 1}, label="L")
+    ldn = LvlDataNode(dn=dn, split_lvl="A")
+    sdn = SplitDataNode(split_var="Var", A=ldn)
+    dt = DataTree(Var=sdn)
+    with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
+        tmp_path = f.name
+    json_str = dt.to_json(path=tmp_path)
+    with open(tmp_path, "r") as f:
+        file_content = f.read()
+    assert file_content == json_str
+    assert json.loads(file_content)["type"] == "DataTree"
+
+
+def test_data_tree_to_json_indent():
+    dt = DataTree()
+    assert "\n" in dt.to_json(indent=2)  # indented output has newlines
+
+
+# ---------------------------------------------------------------------------
+# Integration: run AnalysisTree → DataTree.to_json
+# ---------------------------------------------------------------------------
+
+
+ENVIRON = {"np": np, "pd": pd}
+
+
+@pytest.fixture
+def simple_df():
+    return pd.DataFrame(
+        {
+            "A": [10, 20, 30, 40, 50, 60],
+            "Gender": ["M", "F", "M", "F", "M", "F"],
+        }
+    )
+
+
+def test_integration_to_dict_structure(simple_df):
+    tree = (
+        AnalysisTree()
+        .split_by("df.Gender", label="Gender")
+        .analyze_by(n="len(df)", mean_a="np.mean(df.A)", label="stats")
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+    d = result.to_dict()
+
+    assert d["type"] == "DataTree"
+    gender_split = d["children"]["Gender"]
+    assert gender_split["type"] == "SplitDataNode"
+    assert gender_split["split_var"] == "df.Gender"
+
+    # Each level exists
+    for lvl_key, lvl_node in gender_split["children"].items():
+        assert lvl_node["type"] == "LvlDataNode"
+        stats_node = lvl_node["children"]["stats"]
+        assert stats_node["type"] == "DataNode"
+        assert "n" in stats_node["summary"]
+        assert "mean_a" in stats_node["summary"]
+
+
+def test_integration_to_json_parseable(simple_df):
+    tree = (
+        AnalysisTree()
+        .split_by("df.Gender", label="Gender")
+        .analyze_by(n="len(df)", mean_a="np.mean(df.A)", label="stats")
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+    json_str = result.to_json()
+    parsed = json.loads(json_str)
+    assert parsed["type"] == "DataTree"
+
+
+def test_integration_numpy_scalars_serializable(simple_df):
+    """numpy scalars in summary must survive json.dumps without error."""
+    tree = AnalysisTree().analyze_by(
+        mean=lambda df: np.mean(df.A), count=lambda df: len(df)
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+    # Should not raise
+    json_str = result.to_json()
+    parsed = json.loads(json_str)
+    # A simple (no-split) tree stores the DataNode as a direct child of DataTree.
+    # The key is the AnalysisNode label; grab the first (and only) child.
+    child = next(iter(parsed["children"].values()))
+    summary = child["summary"]
+    assert "mean" in summary
+    assert "count" in summary
+    # Values must be native Python types after JSON round-trip
+    assert isinstance(summary["count"], int)
+    assert isinstance(summary["mean"], float)
+
+
+def test_integration_nan_in_summary():
+    """NaN in summary becomes the string 'NaN' in JSON output."""
+    df = pd.DataFrame({"A": [float("nan"), float("nan")]})
+    tree = AnalysisTree().analyze_by(mean="np.mean(df.A.values)")
+    result = tree.run(df, environ=ENVIRON)
+    parsed = json.loads(result.to_json())
+    # Grab the single DataNode child regardless of its label key
+    child = next(iter(parsed["children"].values()))
+    summary = child["summary"]
+    assert summary["mean"] == "NaN"


### PR DESCRIPTION
This pull request adds robust support for exporting analysis results from `DataTree` and related classes to JSON, making it easy to share computed statistics with LLM agents or other tools. It introduces a `to_json` method (with file output support), ensures all result nodes are serializable (handling edge cases like NaN and numpy types), and provides comprehensive documentation and tests for these features.

**New result serialization and export features:**

* Added `to_dict` and `to_json` methods to `DataNode`, `LvlDataNode`, `SplitDataNode`, and `DataTree` to serialize the hierarchical result tree to a JSON-compatible structure, with options to write directly to a file. These methods ensure only summary statistics are exported (not raw data), and that the JSON is always valid and LLM-friendly. [[1]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3R158-R180) [[2]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3R272-R288) [[3]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3R409-R425) [[4]](diffhunk://#diff-00cbb5ac463da970bc519b20fd9a083338802210b37e5cd5cb91911c9875b0e3R529-R600)
* Implemented a helper function `_serialize_summary_value` to convert summary values into JSON-safe types, including special handling for `NaN`, `Infinity`, and numpy scalar types.

**Documentation improvements:**

* Added a new section to the interoperability guide (`docs/guides/interoperability.rst`) explaining how to export results to JSON, describing the structure, usage examples, and special value handling for LLM workflows.

**Testing and robustness:**

* Added extensive unit and integration tests for the new serialization helpers, the `to_dict`/`to_json` methods, and their handling of edge cases (such as numpy types, NaN, and file output). [[1]](diffhunk://#diff-913b7b4b75352927bdc3f329123792c8be06a53da352bdefa29811defe25a855L1-R10) [[2]](diffhunk://#diff-913b7b4b75352927bdc3f329123792c8be06a53da352bdefa29811defe25a855R83-R379)

These changes make it straightforward to export, share, and consume analysis results in downstream applications and LLM pipelines.