### PR TITLE
use image plot in gt table

### DIFF
--- a/examples/notebooks/08_forest_table.ipynb
+++ b/examples/notebooks/08_forest_table.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b4e39616",
+   "metadata": {},
+   "source": [
+    "# Forest Plot Table (`gt_forest_table`)\n",
+    "\n",
+    "`gt_forest_table()` renders a [Great Tables](https://posit-dev.github.io/great-tables/) table where each row carries an inline forest plot — a CI whisker + point estimate dot + reference line — generated with matplotlib and embedded as a base64 PNG.\n",
+    "\n",
+    "**When to use it:** whenever you want a publication-style summary table with a visual forest plot column alongside plain-text statistics (n, p-value, etc.) and hierarchical row labels produced by a `DataTree`.\n",
+    "\n",
+    "**Key parameters**\n",
+    "\n",
+    "| Parameter | Description |\n",
+    "|-----------|-------------|\n",
+    "| `x` | Stat column name for the **point estimate** |\n",
+    "| `xmin` | Stat column name for the **lower CI bound** |\n",
+    "| `xmax` | Stat column name for the **upper CI bound** |\n",
+    "| `info_columns` | `...` (default) = all other stat cols; `None` = none; `list[str]` = explicit selection |\n",
+    "| `ref_line` | X position of the vertical reference line (default `1.0`) |\n",
+    "| `autoscale` | Share x-axis range across all rows (default `True`) |\n",
+    "| `cascade` | Include structural tree nodes as rows (default `False`) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96643ca2",
+   "metadata": {},
+   "source": [
+    "## 1 — Imports and sample data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67637fa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pyMyriad import AnalysisTree, gt_forest_table\n",
+    "\n",
+    "rng = np.random.default_rng(42)\n",
+    "\n",
+    "n = 500\n",
+    "df = pd.DataFrame({\n",
+    "    \"Treatment\": rng.choice([\"Drug A\", \"Drug B\", \"Placebo\"], n),\n",
+    "    \"Site\":      rng.choice([\"Site 1\", \"Site 2\", \"Site 3\"], n),\n",
+    "    \"Sex\":       rng.choice([\"M\", \"F\"], n),\n",
+    "    # Simulated log-odds-ratio-like outcome (centred near 0)\n",
+    "    \"logOR\": rng.normal(loc=0.1, scale=0.8, size=n),\n",
+    "    \"n_events\": rng.integers(1, 20, n),\n",
+    "})\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8256a029",
+   "metadata": {},
+   "source": [
+    "## 2 — Basic forest table\n",
+    "\n",
+    "The analysis tree produces three statistics named `x`, `xmin`, `xmax`.  \n",
+    "Pass those names to `gt_forest_table()` and you get an interactive GT table with one inline plot per row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8272b480",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mean_ci(df, alpha=1.96):\n",
+    "    \"\"\"Return point estimate and 95 % CI for mean logOR.\"\"\"\n",
+    "    se = np.std(df.logOR, ddof=1) / np.sqrt(len(df))\n",
+    "    m  = np.mean(df.logOR)\n",
+    "    return m, m - alpha * se, m + alpha * se\n",
+    "\n",
+    "tree_basic = (\n",
+    "    AnalysisTree()\n",
+    "    .split_by(\"df.Treatment\")\n",
+    "    .analyze_by(\n",
+    "        x    = lambda df: mean_ci(df)[0],\n",
+    "        xmin = lambda df: mean_ci(df)[1],\n",
+    "        xmax = lambda df: mean_ci(df)[2],\n",
+    "        n    = lambda df: len(df),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "result_basic = tree_basic.run(df)\n",
+    "\n",
+    "gt_forest_table(\n",
+    "    result_basic,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Mean log-OR by Treatment\",\n",
+    "    subtitle=\"Error bars show 95 % CI\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a4efeba",
+   "metadata": {},
+   "source": [
+    "## 3 — Controlling what extra columns appear (`info_columns`)\n",
+    "\n",
+    "By default every stat column that isn't part of the CI triple is shown as plain text.  \n",
+    "Pass `info_columns=None` to suppress them, or supply a list to pick exact columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9a9f74d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Only the forest plot column, no extra stats\n",
+    "gt_forest_table(\n",
+    "    result_basic,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    info_columns=None,\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Plot only — no info columns\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33c3dd85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show only the 'n' column alongside the plot\n",
+    "gt_forest_table(\n",
+    "    result_basic,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    info_columns=[\"n\"],\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Plot + sample size only\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bfbe920",
+   "metadata": {},
+   "source": [
+    "## 4 — Nested splits (two-level hierarchy)\n",
+    "\n",
+    "Use multiple `split_by()` calls to produce a two-level table.  \n",
+    "Row labels are split across `Level 0` / `Level 1` columns automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed4e9a89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree_nested = (\n",
+    "    AnalysisTree()\n",
+    "    .split_by(\"df.Treatment\")\n",
+    "    .split_by(\"df.Sex\")\n",
+    "    .analyze_by(\n",
+    "        x    = lambda df: mean_ci(df)[0],\n",
+    "        xmin = lambda df: mean_ci(df)[1],\n",
+    "        xmax = lambda df: mean_ci(df)[2],\n",
+    "        n    = lambda df: len(df),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "result_nested = tree_nested.run(df)\n",
+    "\n",
+    "gt_forest_table(\n",
+    "    result_nested,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    info_columns=[\"n\"],\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Mean log-OR by Treatment × Sex\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f668d95",
+   "metadata": {},
+   "source": [
+    "## 5 — `cascade=True`: show intermediate summary rows\n",
+    "\n",
+    "Set `cascade=True` to include split/summary nodes in the table.  \n",
+    "Those rows have no CI values, so the Forest Plot cell is left blank — which is the correct visual treatment for structural rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d429d0c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree_cascade = (\n",
+    "    AnalysisTree()\n",
+    "    .split_by(\"df.Treatment\")\n",
+    "    .summarize_by(\n",
+    "        x    = lambda df: mean_ci(df)[0],\n",
+    "        xmin = lambda df: mean_ci(df)[1],\n",
+    "        xmax = lambda df: mean_ci(df)[2],\n",
+    "        n    = lambda df: len(df),\n",
+    "    )\n",
+    "    .split_by(\"df.Site\")\n",
+    "    .analyze_by(\n",
+    "        x    = lambda df: mean_ci(df)[0],\n",
+    "        xmin = lambda df: mean_ci(df)[1],\n",
+    "        xmax = lambda df: mean_ci(df)[2],\n",
+    "        n    = lambda df: len(df),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "result_cascade = tree_cascade.run(df)\n",
+    "\n",
+    "gt_forest_table(\n",
+    "    result_cascade,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    cascade=True,\n",
+    "    info_columns=[\"n\"],\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Treatment summaries + Site breakdown\",\n",
+    "    subtitle=\"Structural rows have blank forest plot cells\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d45e526",
+   "metadata": {},
+   "source": [
+    "## 6 — `autoscale=False`: per-row axis range\n",
+    "\n",
+    "When `autoscale=False` each plot uses its own x-axis range.  \n",
+    "Useful when rows have very different magnitudes and visual comparison across rows is not the goal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a4ad1f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt_forest_table(\n",
+    "    result_basic,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    autoscale=False,\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Per-row axis range (autoscale=False)\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aefe7761",
+   "metadata": {},
+   "source": [
+    "## 7 — Mixed analyses: not every row has CI columns\n",
+    "\n",
+    "When one `analyze_by` node produces `x`/`xmin`/`xmax` and another does not (e.g. a count-only node), the rows that lack CI data simply show a blank Forest Plot cell — no error is raised."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b2ad5b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree_mixed = (\n",
+    "    AnalysisTree()\n",
+    "    .split_by(\"df.Treatment\")\n",
+    "    .analyze_by(\n",
+    "        x    = lambda df: mean_ci(df)[0],\n",
+    "        xmin = lambda df: mean_ci(df)[1],\n",
+    "        xmax = lambda df: mean_ci(df)[2],\n",
+    "        label=\"CI\",\n",
+    "    )\n",
+    "    .analyze_by(\n",
+    "        n = lambda df: len(df),\n",
+    "        label=\"Count\",\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "result_mixed = tree_mixed.run(df)\n",
+    "\n",
+    "gt_forest_table(\n",
+    "    result_mixed,\n",
+    "    x=\"x\", xmin=\"xmin\", xmax=\"xmax\",\n",
+    "    ref_line=0.0,\n",
+    "    title=\"Mixed analyses — Count rows have blank plot cells\",\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/pyMyriad/__init__.py
+++ b/src/pyMyriad/__init__.py
@@ -6,6 +6,7 @@ from .data_tree import DataTree, SplitDataNode, LvlDataNode, DataNode
 from .plots import forest_plot, distribution_plot
 from .listing import gt_table, simple_table, cascade_table
 from .tabular import format_statistics
+from .plot_table import gt_forest_table
 
 __all__ = [
     "AnalysisTree",
@@ -21,4 +22,5 @@ __all__ = [
     "simple_table",
     "cascade_table",
     "format_statistics",
+    "gt_forest_table",
 ]

--- a/src/pyMyriad/listing.py
+++ b/src/pyMyriad/listing.py
@@ -271,7 +271,7 @@ def _create_table(
 
     elif pivot_statistics:
         # Pivot only by statistics
-        pivot_columns = df["statistics"].unique().tolist()
+        pivot_columns = [c for c in df["statistics"].unique().tolist() if c is not None]
         df = df.pivot_table(
             index=["depth", "path_pivot", "label"],
             columns="statistics",

--- a/src/pyMyriad/plot_table.py
+++ b/src/pyMyriad/plot_table.py
@@ -1,0 +1,243 @@
+"""Forest plot table module.
+
+This module provides a function for creating Great Tables (GT) tables with
+inline forest plot images representing estimates and confidence intervals.
+
+The hierarchy columns produced by simple_table() / cascade_table() become
+the row identifiers, while an inline matplotlib forest plot (CI bar, estimate
+dot, optional reference line) is rendered per row and embedded as a
+base64-encoded PNG image.
+
+Rows where CI columns are missing (NaN) — structural rows from cascade=True,
+or analyses that produce different statistics — display a blank cell.
+
+Main function:
+- gt_forest_table(): Create a GT table with inline forest plots from a DataTree
+
+Example:
+    >>> from pyMyriad import AnalysisTree, gt_forest_table
+    >>>
+    >>> tree = AnalysisTree().split_by('df.Gender').analyze_by(
+    ...     x=lambda df: np.mean(df.Income),
+    ...     xmin=lambda df: np.mean(df.Income) - 1.96 * np.std(df.Income) / np.sqrt(len(df)),
+    ...     xmax=lambda df: np.mean(df.Income) + 1.96 * np.std(df.Income) / np.sqrt(len(df)),
+    ... )
+    >>> result = tree.run(df)
+    >>>
+    >>> # Forest plot table with all statistic columns shown
+    >>> gt_forest_table(result, x='x', xmin='xmin', xmax='xmax')
+    >>>
+    >>> # Title, no extra info columns
+    >>> gt_forest_table(result, x='x', xmin='xmin', xmax='xmax',
+    ...                 title='Income by Gender', info_columns=None)
+    >>>
+    >>> # Include all tree nodes
+    >>> gt_forest_table(result, x='x', xmin='xmin', xmax='xmax', cascade=True)
+
+See also:
+    - listing.py: simple_table, cascade_table, gt_table
+    - plots.py: forest_plot, distribution_plot
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from great_tables import GT
+
+import pandas as pd
+
+from .data_tree import DataTree
+from .listing import cascade_table, simple_table
+
+# Sentinel for the "show all non-CI stat columns" default
+_UNSET = object()
+
+
+def _make_forest_b64(
+    ci_low,
+    x_val,
+    ci_high,
+    x_axis_min: float,
+    x_axis_max: float,
+    ref_line: float,
+) -> str:
+    """Render one forest-plot row as a base64-encoded PNG string.
+
+    Returns ``""`` when any of the three values is missing (NaN/None).
+    Uses the non-interactive Agg backend directly to avoid altering global
+    matplotlib state.
+    """
+    if pd.isna(ci_low) or pd.isna(x_val) or pd.isna(ci_high):
+        return ""
+
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+
+    fig = Figure(figsize=(2.5, 0.4))
+    FigureCanvasAgg(fig)
+    ax = fig.add_subplot(1, 1, 1)
+    ax.plot([float(ci_low), float(ci_high)], [0, 0], color="#aaaaaa", linewidth=1.5)
+    ax.scatter([float(x_val)], [0], color="#2171b5", s=40, zorder=3)
+    ax.axvline(x=ref_line, color="black", linewidth=0.8, linestyle="--")
+    ax.set_xlim(x_axis_min, x_axis_max)
+    ax.axis("off")
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight", dpi=150, transparent=True)
+    buf.seek(0)
+    return base64.b64encode(buf.read()).decode("ascii")
+
+
+def gt_forest_table(
+    dtree: DataTree,
+    x: str,
+    xmin: str,
+    xmax: str,
+    info_columns=_UNSET,
+    cascade: bool = False,
+    by: str = "",
+    autoscale: bool = True,
+    suppress_duplicates: bool = True,
+    ref_line: float = 1.0,
+    title: str | None = None,
+    subtitle: str | None = None,
+) -> "GT":
+    """Create a Great Tables table with inline forest plots from a DataTree.
+
+    Calls simple_table() or cascade_table() with pivot_statistics=True,
+    then renders one matplotlib forest plot per row (CI bar + estimate dot +
+    reference line) embedded as a base64 PNG image in the table.
+
+    Rows where the CI columns are missing (NaN) — for example structural rows
+    from cascade=True, or analyses that produce different statistics — display
+    a blank cell instead of a plot.
+
+    Args:
+        dtree (DataTree): The DataTree containing analysis results.
+        x (str): Name of the statistic column used as the point estimate.
+        xmin (str): Name of the statistic column used as the lower CI bound.
+        xmax (str): Name of the statistic column used as the upper CI bound.
+        info_columns: Statistic columns to display as plain text alongside the
+            plot. Pass ``...`` (default) to show all non-CI columns, ``None``
+            to show none, or a ``list[str]`` for an explicit selection.
+        cascade (bool): If True, use cascade_table() for all tree nodes.
+            Defaults to False.
+        by (str): Split variable to pivot across columns, forwarded to the
+            underlying table function. Defaults to "".
+        autoscale (bool): If True, all forest plots share the same x-axis
+            scale, enabling visual comparison across rows. Defaults to True.
+        suppress_duplicates (bool): If True, suppress consecutive duplicate
+            values in hierarchy columns for cleaner display. Defaults to True.
+        ref_line (float): X position of the vertical reference line (e.g. 1.0
+            for odds ratios, 0.0 for mean differences). Defaults to 1.0.
+        title (str | None): Optional table title for GT.tab_header().
+        subtitle (str | None): Optional table subtitle for GT.tab_header().
+
+    Returns:
+        GT: A Great Tables GT object ready to display or export.
+
+    Raises:
+        ValueError: If x, xmin, or xmax is not found in the table.
+        ValueError: If a name in info_columns is not found in the table.
+
+    Examples:
+        >>> gt_forest_table(result, x='x', xmin='xmin', xmax='xmax')
+        >>> gt_forest_table(result, x='x', xmin='xmin', xmax='xmax',
+        ...                 title='OR by Gender', info_columns=None)
+        >>> gt_forest_table(result, x='x', xmin='xmin', xmax='xmax',
+        ...                 cascade=True, ref_line=0.0)
+    """
+    from great_tables import GT
+
+    # --- 1. Build wide-format table -----------------------------------------
+    table_fn = cascade_table if cascade else simple_table
+    df = table_fn(
+        dtree,
+        by=by,
+        pivot_statistics=True,
+        suppress_duplicates=suppress_duplicates,
+        split_path=True,
+    )
+
+    # --- 2. Identify column roles -------------------------------------------
+    level_cols = [c for c in df.columns if c.startswith("_Level_")]
+    ci_cols = {x, xmin, xmax}
+    all_stat_cols = [c for c in df.columns if c not in level_cols]
+
+    # --- 3. Validate CI columns ---------------------------------------------
+    for col in (x, xmin, xmax):
+        if col not in df.columns:
+            raise ValueError(
+                f"Column {col!r} not found in table. "
+                f"Available columns: {all_stat_cols}"
+            )
+
+    # --- 4. Resolve info_columns --------------------------------------------
+    if info_columns is _UNSET:
+        resolved_info = [c for c in all_stat_cols if c not in ci_cols]
+    elif info_columns is None:
+        resolved_info = []
+    else:
+        resolved_info = list(info_columns)  # type: ignore[arg-type]
+        for col in resolved_info:
+            if col not in df.columns:
+                raise ValueError(
+                    f"info_columns: column {col!r} not found in table. "
+                    f"Available columns: {all_stat_cols}"
+                )
+
+    # --- 5. Compute global x-axis range for autoscale -----------------------
+    valid_range_df = df[[xmin, xmax]].dropna()
+    x_axis_min_global: float = ref_line - 1.0
+    x_axis_max_global: float = ref_line + 1.0
+    if not valid_range_df.empty and autoscale:
+        lo = float(valid_range_df[xmin].min())
+        hi = float(valid_range_df[xmax].max())
+        pad = (hi - lo) * 0.05 if hi > lo else 0.1
+        x_axis_min_global = lo - pad
+        x_axis_max_global = hi + pad
+    # When autoscale=False, per-row range is computed in the loop below
+
+    # --- 6. Generate per-row forest plot images -----------------------------
+    df = df.copy()
+    plot_cells = []
+    for _, row in df.iterrows():
+        if autoscale:
+            row_min, row_max = x_axis_min_global, x_axis_max_global
+        else:
+            if pd.isna(row[xmin]) or pd.isna(row[xmax]):
+                row_min, row_max = ref_line - 1.0, ref_line + 1.0
+            else:
+                lo, hi = float(row[xmin]), float(row[xmax])
+                pad = (hi - lo) * 0.05 if hi > lo else 0.1
+                row_min, row_max = lo - pad, hi + pad
+
+        b64 = _make_forest_b64(row[xmin], row[x], row[xmax], row_min, row_max, ref_line)
+        plot_cells.append(
+            f'<img src="data:image/png;base64,{b64}" style="height:1.5em;"/>' if b64 else ""
+        )
+    df["_plot"] = plot_cells
+
+    # --- 7. Build display DataFrame -----------------------------------------
+    df_display = df[level_cols + resolved_info + ["_plot"]]
+
+    # --- 8. Build GT --------------------------------------------------------
+    gt = GT(df_display)
+
+    level_label_map = {
+        col: col.replace("_Level_", "Level ").strip() for col in level_cols
+    }
+    if level_label_map:
+        gt = gt.cols_label(**level_label_map)  # type: ignore[arg-type]
+
+    gt = gt.cols_label(_plot="Forest Plot")  # type: ignore[arg-type]
+    gt = gt.fmt_markdown(columns="_plot")
+
+    if title is not None or subtitle is not None:
+        gt = gt.tab_header(title=title or "", subtitle=subtitle)
+
+    return gt

--- a/tests/test_plot_table.py
+++ b/tests/test_plot_table.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pytest
+import pandas as pd
+from importlib import import_module
+from contextlib import contextmanager
+
+from great_tables import GT
+from pyMyriad import AnalysisTree, gt_forest_table
+
+
+@contextmanager
+def with_module(module_name, module_abr):
+    module = import_module(module_name)
+    yield {module_abr: module}
+
+
+@pytest.fixture
+def simple_dtree():
+    atree = (
+        AnalysisTree()
+        .split_by("df.VAR1")
+        .split_by("df.VAR2 > 50")
+        .analyze_by(
+            x="np.mean(df.val)",
+            xmin="np.min(df.val)",
+            xmax="np.max(df.val)",
+        )
+    )
+    df = pd.DataFrame(
+        {
+            "VAR1": ["A", "A", "A", "B", "B", "B"],
+            "VAR2": [10, 60, 70, 20, 80, 90],
+            "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        }
+    )
+    with with_module("numpy", "np") as environ:
+        return atree.run(df, environ=environ)
+
+
+@pytest.fixture
+def mixed_label_dtree():
+    """Tree with two analyses: one with CI columns, one without."""
+    atree = (
+        AnalysisTree()
+        .analyze_by(
+            x="np.mean(df.val)",
+            xmin="np.min(df.val)",
+            xmax="np.max(df.val)",
+            label="ci",
+        )
+        .analyze_by(n="len(df)", label="count")
+    )
+    df = pd.DataFrame({"val": [1.0, 2.0, 3.0, 4.0]})
+    with with_module("numpy", "np") as environ:
+        return atree.run(df, environ=environ)
+
+
+def test_import():
+    from pyMyriad import gt_forest_table  # noqa: F401
+
+
+def test_returns_gt_object(simple_dtree):
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax")
+    assert isinstance(result, GT)
+
+
+def test_cascade_true(simple_dtree):
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax", cascade=True)
+    assert isinstance(result, GT)
+
+
+def test_title_and_subtitle(simple_dtree):
+    result = gt_forest_table(
+        simple_dtree, x="x", xmin="xmin", xmax="xmax",
+        title="Test", subtitle="Sub",
+    )
+    assert isinstance(result, GT)
+
+
+def test_ref_line_zero(simple_dtree):
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax", ref_line=0.0)
+    assert isinstance(result, GT)
+
+
+def test_autoscale_false(simple_dtree):
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax", autoscale=False)
+    assert isinstance(result, GT)
+
+
+def test_suppress_duplicates_false(simple_dtree):
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax", suppress_duplicates=False)
+    assert isinstance(result, GT)
+
+
+def test_info_columns_default(simple_dtree):
+    """Default sentinel: no extra stat cols in this fixture, _plot is the only extra col."""
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax")
+    assert isinstance(result, GT)
+
+
+def test_info_columns_none(simple_dtree):
+    """None: only hierarchy + _plot column, no stat columns shown."""
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax", info_columns=None)
+    assert isinstance(result, GT)
+
+
+def test_info_columns_empty_list(simple_dtree):
+    result = gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="xmax", info_columns=[])
+    assert isinstance(result, GT)
+
+
+def test_invalid_x_col_raises(simple_dtree):
+    with pytest.raises(ValueError, match="not found in table"):
+        gt_forest_table(simple_dtree, x="nonexistent", xmin="xmin", xmax="xmax")
+
+
+def test_invalid_xmin_col_raises(simple_dtree):
+    with pytest.raises(ValueError, match="not found in table"):
+        gt_forest_table(simple_dtree, x="x", xmin="nonexistent", xmax="xmax")
+
+
+def test_invalid_xmax_col_raises(simple_dtree):
+    with pytest.raises(ValueError, match="not found in table"):
+        gt_forest_table(simple_dtree, x="x", xmin="xmin", xmax="nonexistent")
+
+
+def test_invalid_info_column_raises(simple_dtree):
+    with pytest.raises(ValueError, match="not found in table"):
+        gt_forest_table(
+            simple_dtree, x="x", xmin="xmin", xmax="xmax",
+            info_columns=["nonexistent_col"],
+        )
+
+
+def test_cascade_structural_rows_no_error(simple_dtree):
+    """cascade=True produces structural rows with NaN CI values; should not error."""
+    result = gt_forest_table(
+        simple_dtree, x="x", xmin="xmin", xmax="xmax", cascade=True
+    )
+    assert isinstance(result, GT)
+
+
+def test_mixed_labels_no_error(mixed_label_dtree):
+    """Rows lacking x/xmin/xmax (NaN) produce blank _plot cells, not errors."""
+    result = gt_forest_table(mixed_label_dtree, x="x", xmin="xmin", xmax="xmax")
+    assert isinstance(result, GT)
+


### PR DESCRIPTION
This pull request introduces a new feature for generating publication-quality forest plot tables, along with supporting documentation, tests, and minor improvements to existing code. The main addition is the `gt_forest_table` function, which creates a Great Tables (GT) table with inline matplotlib forest plots for each row, supporting various customization options. The update also includes a comprehensive example notebook, robust test coverage, and a small fix in the statistics pivoting logic.

**New Feature: Forest Plot Table**

* Added `gt_forest_table` function in the new `plot_table.py` module, which builds a GT table with inline forest plots (matplotlib-generated, base64-embedded) for each row, supporting flexible options for CI columns, info columns, axis scaling, and inclusion of hierarchical rows.
* Exposed `gt_forest_table` in the public API by updating `__init__.py` imports and `__all__`. [[1]](diffhunk://#diff-48f09b2fd1414f189b5ed0392712185bb70904184007349fce0ddb287d126ea5R9) [[2]](diffhunk://#diff-48f09b2fd1414f189b5ed0392712185bb70904184007349fce0ddb287d126ea5R25)

**Documentation and Examples**

* Added a detailed example notebook `08_forest_table.ipynb` demonstrating usage scenarios, key parameters, and advanced features of `gt_forest_table`.

**Testing**

* Added `test_plot_table.py` with comprehensive tests for `gt_forest_table`, covering correct output, error handling, and edge cases (e.g., missing CI columns, mixed analyses, cascade rows).

**Bug Fix**

* Fixed a bug in `listing.py` where `None` values could appear in pivot columns when pivoting statistics, ensuring only valid columns are included.