### PR TITLE
chore: add .pre-commit-config.yaml (ruff lint + format)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.10  # keep in sync with pyproject.toml [dependency-groups] dev ruff version
+    hooks:
+      - id: ruff          # lint + auto-fix
+        args: [--fix]
+      - id: ruff-format   # format


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` at the repo root, resolving #51
- Two hooks: `ruff` (lint + auto-fix) and `ruff-format`, pinned to `v0.12.10` to match `pyproject.toml`'s `ruff>=0.12.10` dev dependency
- Mirrors CI exactly (`ruff check .` and `ruff format --check .` in `.github/workflows/ci.yml`)

## Test plan

- [ ] `pre-commit install` after a fresh dev setup installs hooks
- [ ] `pre-commit run --all-files` passes on the current codebase
- [ ] A commit with a lint/format violation is rejected locally before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)