### PR TITLE
docs: point agents to CONTRIBUTING.md from quick reference

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -7,6 +7,7 @@ This file provides guidance to GitHub Copilot and other AI coding assistants whe
 - **Architecture**: See [ARCHITECTURE.md](ARCHITECTURE.md) for complete architectural overview
 - **Examples**: See [examples/EXAMPLES_GUIDE.md](examples/EXAMPLES_GUIDE.md) for usage patterns
 - **API Exports**: See [src/pyMyriad/__init__.py](src/pyMyriad/__init__.py) for public API
+- **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, branch naming, commit conventions, and PR workflow
 
 ## Core Concepts
 
@@ -244,11 +245,9 @@ format_statistics(dtree: DataTree, summary: str = "{value}", **kwargs) -> DataTr
 
 ## Documentation Style
 
-- Use Google-style docstrings
-- Include Examples section in docstrings
 - Document parameter types and return types
-- Provide both simple and complex usage examples
-- Link to ARCHITECTURE.md for detailed explanations
+- Provide both simple and complex usage examples in docstrings
+- For conventions (docstring format, what files to update): see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Dependencies
 
@@ -259,7 +258,7 @@ format_statistics(dtree: DataTree, summary: str = "{value}", **kwargs) -> DataTr
 **Testing**: pytest
 **Docs**: sphinx, sphinx-rtd-theme
 
-Avoid adding new dependencies without discussion.
+See [CONTRIBUTING.md](CONTRIBUTING.md) checklist before adding new dependencies.
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

Updates `.copilot-instructions.md` (which `CLAUDE.md` symlinks to) so AI agents are directed to read `CONTRIBUTING.md` alongside the code instructions.

**Note:** `CLAUDE.md` is a symlink to `.copilot-instructions.md` — one file serves both Claude Code and GitHub Copilot.

## Changes

- Added `CONTRIBUTING.md` to the Quick Reference section (agents now see it on first read)
- Trimmed `Documentation Style` section: removed bullets already covered by CONTRIBUTING.md, kept AI-specific guidance, added pointer
- Trimmed `Dependencies` section: replaced "Avoid adding new dependencies without discussion" with a link to the CONTRIBUTING.md checklist

## Testing

- [x] Existing tests pass (`pytest`)

## Checklist

- [x] No new dependencies added without discussion (see `pyproject.toml`)
- [x] `ARCHITECTURE.md` / `CLAUDE.md` updated if architecture changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)