### PR TITLE
docs: add module-level docstring to __init__.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `drop_empty` parameter on `split_by()`, `split_at_by()`, and `split_at_root_by()` (and on `SplitNode` directly) to optionally discard split levels that produce an empty DataFrame. Defaults to `False` (backward-compatible). Useful when conditional splits may not be satisfied by every subset of the data.
 - Categorical column support: `SplitNode.run()` now ties `observed=<drop_empty>` in `pandas.groupby` to the `drop_empty` parameter, so categorical split behavior is consistent with all other splits. With `drop_empty=False` (default) all category levels—including those with zero observations—are retained as empty DataFrames. With `drop_empty=True` only observed (non-empty) category levels are returned. Passing an explicit value for `observed` also silences the pandas ≥ 2.2 `FutureWarning` about the `observed` default changing. Both `groupby` calls in `plots.py` were updated to `observed=True` for the same reason.
 
+### Documentation
+- Added a module-level docstring to `src/pyMyriad/__init__.py` grouping the 13 public exports by purpose (construction, results, tables, plots, formatting) with one-line descriptions and a workflow example, so `help(pyMyriad)` is now useful (#47).
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/src/pyMyriad/__init__.py
+++ b/src/pyMyriad/__init__.py
@@ -1,3 +1,41 @@
+"""
+pyMyriad — hierarchical analysis tree framework for stratified data analysis.
+
+**Building an analysis (construction side)**
+  AnalysisTree   Root container; start here. ``AnalysisTree().split_by(...).analyze_by(...)``
+  SplitNode      Represents a data split/stratification step.
+  AnalysisNode   Represents a computation step.
+
+**Reading results (results side)**
+  DataTree       Root result container returned by ``AnalysisTree.run()``.
+  SplitDataNode  Results of a split operation, keyed by level.
+  LvlDataNode    Results for a single level within a split.
+  DataNode       Leaf node holding computed summary statistics.
+
+**Exporting to tables**
+  simple_table   Flat pandas DataFrame, one row per analysis.
+  cascade_table  Hierarchical DataFrame including split and summary rows.
+  gt_table       Formatted HTML table via great-tables.
+
+**Exporting to plots**
+  forest_plot        Forest plot for effect sizes with error bars.
+  distribution_plot  Distribution / scatter plot of raw data.
+
+**Formatting**
+  format_statistics  Apply format strings to combine statistics in a DataTree.
+
+Typical workflow::
+
+    import pandas as pd, numpy as np
+    from pyMyriad import AnalysisTree, simple_table
+
+    tree = AnalysisTree().split_by("df.Group").analyze_by(n=lambda df: len(df))
+    result = tree.run(df)
+    print(simple_table(result))
+
+See ARCHITECTURE.md for a full architectural overview.
+"""
+
 __version__ = "0.1.0"
 
 


### PR DESCRIPTION
## Summary
- Adds a module-level docstring to `src/pyMyriad/__init__.py` that groups all 13 public exports by purpose (construction, results, tables, plots, formatting) with one-line descriptions and a short workflow example.
- Previously `help(pyMyriad)` returned nothing useful, forcing humans and AI agents to infer each symbol's purpose from its name alone.
- Adds a `### Documentation` entry under `[Unreleased]` in CHANGELOG.md per the contributing guide.

closes #47

## Test plan
- [x] `python -c "import pyMyriad; print(pyMyriad.__doc__)"` renders the full grouped docstring
- [x] `pytest` — 133 passed, 6 deselected (no behavior change, docstring-only)
- [x] `ruff check` / `ruff format --check` pass on changed files