### PR TITLE
fix: by= argument matched split labels via substring instead of exact equality

### DIFF
--- a/src/pyMyriad/data_tree.py
+++ b/src/pyMyriad/data_tree.py
@@ -40,6 +40,48 @@ import pandas as pd
 from .utils import analysis_to_string
 
 
+def _normalize_pivot_labels(pivot) -> tuple:
+    """Normalize a ``by``/``pivot`` argument into a tuple of exact split labels.
+
+    Accepts a single label as a string, an iterable of labels, or the
+    "no pivot" defaults (``None``, ``""``, ``()``). A bare string is wrapped
+    into a single-element tuple so that downstream membership checks
+    (``label in pivot_labels``) always test exact equality against one or
+    more labels, instead of accidentally testing whether ``label`` is a
+    *substring* of a single pivot string (e.g. ``"Arm" in "df.ARM"`` is
+    ``False`` while ``"Arm" in "df.Arm"`` is ``True`` purely by coincidence).
+
+    Args:
+        pivot: The raw ``by``/``pivot`` value as supplied by the caller.
+
+    Returns:
+        tuple: A tuple of label strings to match exactly against split labels.
+    """
+    if pivot is None or pivot == "":
+        return ()
+    if isinstance(pivot, str):
+        return (pivot,)
+    return tuple(pivot)
+
+
+def _collect_split_labels(node) -> set:
+    """Recursively collect every ``SplitDataNode`` label reachable from `node`.
+
+    Used to validate a ``by``/``pivot`` request against the labels that
+    actually exist in the tree, so a typo or mismatched label produces a
+    clear error instead of a silently unpivoted table.
+    """
+    labels = set()
+    if isinstance(node, SplitDataNode):
+        labels.add(node.label)
+        for child in node.values():
+            labels.update(_collect_split_labels(child))
+    elif isinstance(node, LvlDataNode):
+        for child in node.values():
+            labels.update(_collect_split_labels(child))
+    return labels
+
+
 def _serialize_summary_value(val):
     """Convert a summary value to a JSON-safe Python type.
 
@@ -188,7 +230,6 @@ class DataNode:
         pivot_lvl=(),
         data: bool = False,
     ) -> pd.DataFrame:
-
         path = path + ("analysis",)
         path_pivot = path_pivot + ("analysis",)
 
@@ -295,7 +336,6 @@ class SplitDataNode(dict):
         pivot_lvl=(),
         data: bool = False,
     ) -> pd.DataFrame:
-
         path = path + (self.label,)  # split_var
 
         if self.label in pivot_var:
@@ -601,10 +641,27 @@ class DataTree(dict):
         """Flatten a DataTree into a DataFrame.
         This method flattens the hierarchical structure of the DataTree into a pandas DataFrame.
         Args:
-            pivot (str, optional): The name of a split to pivot by. Defaults to an empty tuple.
+            pivot (str, optional): The label of a split to pivot by, or an iterable of
+                split labels to pivot by simultaneously. Matched by exact equality
+                against split labels. Defaults to an empty tuple (no pivoting).
         Returns:
             pd.DataFrame: A flattened representation of the DataTree.
+        Raises:
+            ValueError: If `pivot` names a label that does not match any split in the tree.
         """
+
+        pivot_var = _normalize_pivot_labels(pivot)
+
+        if pivot_var:
+            known_labels = set()
+            for child in self.values():
+                known_labels.update(_collect_split_labels(child))
+            unknown = [label for label in pivot_var if label not in known_labels]
+            if unknown:
+                raise ValueError(
+                    f"by/pivot label(s) {unknown} do not match any split in the tree. "
+                    f"Known split labels: {sorted(known_labels)}"
+                )
 
         depth = 0
         path = ("root",)
@@ -631,7 +688,7 @@ class DataTree(dict):
             x.__flatten__(
                 path=path,
                 depth=depth + 1,
-                pivot_var=pivot,
+                pivot_var=pivot_var,
                 path_pivot=path_pivot,
                 pivot_split=pivot_split,
                 pivot_lvl=pivot_lvl,

--- a/tests/test_data_tree.py
+++ b/tests/test_data_tree.py
@@ -6,7 +6,11 @@ import pandas as pd
 import pytest
 
 from pyMyriad import AnalysisTree, DataTree, DataNode, LvlDataNode, SplitDataNode
-from pyMyriad.data_tree import _serialize_summary_value
+from pyMyriad.data_tree import (
+    _collect_split_labels,
+    _normalize_pivot_labels,
+    _serialize_summary_value,
+)
 
 
 def test_data_tree_empty():
@@ -376,3 +380,84 @@ def test_integration_nan_in_summary():
     child = next(iter(parsed["children"].values()))
     summary = child["summary"]
     assert summary["mean"] == "NaN"
+
+
+# region _normalize_pivot_labels / _collect_split_labels / by= exact matching (issue #59)
+
+
+def test_normalize_pivot_labels_defaults_to_empty_tuple():
+    assert _normalize_pivot_labels(()) == ()
+    assert _normalize_pivot_labels("") == ()
+    assert _normalize_pivot_labels(None) == ()
+
+
+def test_normalize_pivot_labels_wraps_a_single_string():
+    assert _normalize_pivot_labels("Arm") == ("Arm",)
+
+
+def test_normalize_pivot_labels_passes_through_an_iterable():
+    assert _normalize_pivot_labels(["Arm", "Visit"]) == ("Arm", "Visit")
+    assert _normalize_pivot_labels(("Arm",)) == ("Arm",)
+
+
+def test_collect_split_labels(simple_df):
+    tree = (
+        AnalysisTree()
+        .split_by("df.Gender", label="Gender")
+        .split_by("df.A", label="A Level")
+        .analyze_by(n=lambda df: len(df))
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+    labels = set()
+    for child in result.values():
+        labels.update(_collect_split_labels(child))
+    assert labels == {"Gender", "A Level"}
+
+
+def test_flatten_by_matches_label_exactly_not_as_substring(simple_df):
+    """A split labeled "Gender" must not be pivoted by a string that merely
+    contains "Gender" as a substring (e.g. an unrelated label/expression)."""
+    tree = (
+        AnalysisTree()
+        .split_by("df.Gender", label="Gender")
+        .analyze_by(n=lambda df: len(df))
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+
+    # Exact label match pivots correctly.
+    flat = result.__flatten__(pivot="Gender")
+    assert set(flat["pivot_lvl"].explode().dropna()) == {"M", "F"}
+
+    # A string that merely contains "Gender" as a substring is not a match
+    # and must raise instead of silently returning an unpivoted table.
+    with pytest.raises(ValueError, match="Gender"):
+        result.__flatten__(pivot="prefix.Gender")
+
+
+def test_flatten_by_unknown_label_raises_value_error(simple_df):
+    tree = (
+        AnalysisTree()
+        .split_by("df.Gender", label="Gender")
+        .analyze_by(n=lambda df: len(df))
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+
+    with pytest.raises(ValueError, match="Country"):
+        result.__flatten__(pivot="Country")
+
+
+def test_flatten_by_accepts_list_of_labels(simple_df):
+    tree = (
+        AnalysisTree()
+        .split_by("df.Gender", label="Gender")
+        .split_by("df.A", label="A Level")
+        .analyze_by(n=lambda df: len(df))
+    )
+    result = tree.run(simple_df, environ=ENVIRON)
+    # Should not raise, and should pivot by both labels.
+    flat = result.__flatten__(pivot=["Gender", "A Level"])
+    assert "Gender" in set(flat["pivot_split"].explode().dropna())
+    assert "A Level" in set(flat["pivot_split"].explode().dropna())
+
+
+# endregion

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -486,5 +486,41 @@ def test_helper_suppress_duplicates():
     assert list(result["B"]) == [1, 2, 3, 4, 5]
 
 
+def test_simple_table_by_does_not_substring_match_split_label():
+    """Regression test for #59: by= must match a split's label exactly.
+
+    A split labeled "Arm" must not accidentally pivot (or fail to pivot)
+    based on whether the requested `by` string happens to contain "Arm" as
+    a substring of something else - it must match the label exactly, and
+    raise a clear error when there is no match.
+    """
+    df = pd.DataFrame(
+        {
+            "ARM": ["Placebo", "Active", "Placebo", "Active"],
+            "Outcome": [1, 2, 3, 4],
+        }
+    )
+    atree = (
+        AnalysisTree()
+        .split_by("df.ARM", label="Arm")
+        .analyze_by(mean=lambda df: np.mean(df.Outcome))
+    )
+    dtree = atree.run(df)
+
+    # Exact label match pivots correctly.
+    result = simple_table(dtree, by="Arm")
+    assert "Placebo" in result.columns
+    assert "Active" in result.columns
+
+    # A by= value that happens to contain the label as a substring (or vice
+    # versa) must not silently match - it should raise instead of silently
+    # returning an unpivoted table.
+    with pytest.raises(ValueError, match="Arm"):
+        simple_table(dtree, by="df.ARM")
+
+    with pytest.raises(ValueError, match="Arm"):
+        cascade_table(dtree, by="df.ARM")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `SplitDataNode.__flatten__` (`data_tree.py`) matched the `by=`/`pivot` argument against a split's label with `self.label in pivot_var`. This is exact membership when `pivot_var` is a list, but **silent substring containment** when it's a plain string — which is what every public call site (`simple_table`, `cascade_table`, `gt_table`) passes by default. `by="df.ARM"` against a split labeled `"Arm"` failed to pivot with no error at all (`"Arm" in "df.ARM"` is `False`), while unrelated strings could match purely by accident.
- Added `_normalize_pivot_labels()` to consistently turn `by`/`pivot` (string, iterable, or empty) into a tuple of exact labels before any matching happens, and `_collect_split_labels()` to walk the tree and validate the request — `DataTree.__flatten__` now raises a clear `ValueError` listing the known split labels when `by` doesn't match anything, instead of silently returning an unpivoted table.

## Test plan

- [x] `uv run pytest tests/ -q` — 141 passed
- [x] New unit tests for `_normalize_pivot_labels`/`_collect_split_labels` and `DataTree.__flatten__`'s exact-match + `ValueError` behavior (`tests/test_data_tree.py`)
- [x] New integration test through `simple_table`/`cascade_table` reproducing the original bug and asserting the new error (`tests/test_listing.py`)
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] Re-ran `examples/lab_change_from_baseline_table_v3.py` (uses `by=` with an explicit `label=`) to confirm unaffected — output unchanged

Closes #59.