### PR TITLE
fix: cross_analyze_by callables now dispatch by parameter name like analyze_by

### DIFF
--- a/src/pyMyriad/analysis_tree.py
+++ b/src/pyMyriad/analysis_tree.py
@@ -589,7 +589,19 @@ class AnalysisTree(list):
             label (str, optional): The label for the analysis node. Defaults to an empty string.
             ref_lvl (str, optional): The reference level for comparison. Defaults to an empty string, which lead to comparing every level with each other.
             termination (bool, optional): Indicates if this node is a termination node. Defaults to True.
-            **kwargs: Keyword arguments where keys are analysis names and values are their corresponding expressions.
+            **kwargs: Keyword arguments where keys are analysis names and values are their
+                corresponding expressions. Each value can be a string expression or a callable.
+                Callables are dispatched by parameter name, exactly like ``analyze_by``:
+
+                - ``lambda df: ...`` — receives only the current-level DataFrame.
+                - ``lambda ref_df: ...`` — receives only the reference-level DataFrame.
+                - ``lambda df, ref_df: ...`` — receives both DataFrames (the usual case
+                  for a comparison statistic).
+                - ``lambda df, ref_df, _N: ...`` — also receives the denominator count
+                  list (requires ``denom`` to be set on the :class:`AnalysisTree`).
+
+                A callable must declare at least one of ``df``, ``ref_df``, ``_N`` by name;
+                only the parameters it declares are passed.
 
         Returns:
             AnalysisTree: The modified AnalysisTree with the new cross-analysis node added.
@@ -597,6 +609,10 @@ class AnalysisTree(list):
             >>> a_tree = AnalysisTree()
             >>> a_tree.split_by(m = "df.A > 50")
             >>> a_tree = a_tree.cross_analyze_by(m = "np.mean(df.A) - np.mean(ref_df.A)", s = "np.median(df.B) - np.median(ref_df.B)")
+            >>> a_tree = a_tree.cross_analyze_by(
+            ...     n=lambda df: len(df),
+            ...     mean_diff=lambda df, ref_df: np.mean(df.A) - np.mean(ref_df.A),
+            ... )
         """
 
         for i in range(len(self)):
@@ -1081,7 +1097,19 @@ class SplitNode(list):
             label (str, optional): The label for the analysis node. Defaults to an empty string.
             ref_lvl (str, optional): The reference level for comparison. Defaults to an empty string, which lead to comparing every level with each other.
             termination (bool, optional): Indicates if this node is a termination node. Defaults to True.
-            **kwargs: Keyword arguments where keys are analysis names and values are their corresponding expressions.
+            **kwargs: Keyword arguments where keys are analysis names and values are their
+                corresponding expressions. Each value can be a string expression or a callable.
+                Callables are dispatched by parameter name, exactly like ``analyze_by``:
+
+                - ``lambda df: ...`` — receives only the current-level DataFrame.
+                - ``lambda ref_df: ...`` — receives only the reference-level DataFrame.
+                - ``lambda df, ref_df: ...`` — receives both DataFrames (the usual case
+                  for a comparison statistic).
+                - ``lambda df, ref_df, _N: ...`` — also receives the denominator count
+                  list (requires ``denom`` to be set on the :class:`AnalysisTree`).
+
+                A callable must declare at least one of ``df``, ``ref_df``, ``_N`` by name;
+                only the parameters it declares are passed.
 
         Returns:
             AnalysisTree: The modified AnalysisTree with the new cross-analysis node added.
@@ -1089,6 +1117,10 @@ class SplitNode(list):
             >>> a_tree = AnalysisTree()
             >>> a_tree.split_by(m = "df.A > 50")
             >>> a_tree = a_tree.cross_analyze_by(m = "np.mean(df.A) - np.mean(ref_df.A)", s = "np.median(df.B) - np.median(ref_df.B)")
+            >>> a_tree = a_tree.cross_analyze_by(
+            ...     n=lambda df: len(df),
+            ...     mean_diff=lambda df, ref_df: np.mean(df.A) - np.mean(ref_df.A),
+            ... )
         """
         is_split_node = [isinstance(x, SplitNode) for x in self]
         # length 0 OR (no split node and no termination signal)

--- a/src/pyMyriad/utils.py
+++ b/src/pyMyriad/utils.py
@@ -271,22 +271,29 @@ def scope_cross_eval(
         extra_context (dict, optional): Additional context to include in the evaluation. Defaults to None.
         **kwargs: Expressions to evaluate or functions to execute, where keys are variable names and values are either:
                  - strings (expressions to evaluate, with `df` and `ref_df` available)
-                 - callable functions that take two arguments: (df, ref_df)
+                 - callable functions dispatched by parameter name, the same way `analyze_by`
+                   dispatches callables in `scope_eval`: a function may declare any subset of
+                   `df`, `ref_df`, `_N` and only the parameters it declares are passed.
     Returns:
         dict: A dictionary with keys as the names of the evaluated expressions/functions and values as the results.
     Examples:
         # String expressions comparing two DataFrames
         >>> scope_cross_eval(df=df, ref_df=ref_df, mean_diff="np.mean(df.A) - np.mean(ref_df.A)")
 
-        # Function expressions (must accept two arguments: df and ref_df)
+        # Function expressions taking both df and ref_df
         >>> scope_cross_eval(df=df, ref_df=ref_df, mean_diff=lambda df, ref_df: np.mean(df.A) - np.mean(ref_df.A))
+
+        # Function expressions using only df (e.g. a count that doesn't need ref_df)
+        >>> scope_cross_eval(df=df, ref_df=ref_df, n=lambda df: len(df))
 
         # Mixed usage
         >>> scope_cross_eval(df=df, ref_df=ref_df, mean_diff=lambda df, ref_df: df.A.mean() - ref_df.A.mean(), count="len(df)")
 
     Notes:
-        - For string expressions, both `df` and `ref_df` are available as variables.
-        - For functions, they must accept two arguments: (df, ref_df).
+        - For string expressions, `df`, `ref_df`, and `_N` are all available as variables.
+        - For functions, parameters are matched by name (`df`, `ref_df`, `_N`), exactly like
+          `analyze_by`/`scope_eval` - a function only receives the parameters it declares, so
+          e.g. `lambda df: ...` (valid for `analyze_by`) also works unchanged here.
         - The function uses `eval` for strings, so be cautious about evaluating untrusted input.
     """
 
@@ -307,16 +314,23 @@ def scope_cross_eval(
             has_df = "df" in params
             has_ref_df = "ref_df" in params
             has_N = "_N" in params
+
+            if not (has_df or has_ref_df or has_N):
+                raise TypeError(
+                    f"cross_analyze_by callable for '{name}' must declare at least one "
+                    f"of the parameters 'df', 'ref_df', '_N' (got parameters: {params}). "
+                    "Examples: lambda df: ..., lambda df, ref_df: ..., "
+                    "lambda df, ref_df, _N: ..."
+                )
+
+            call_kwargs = {}
+            if has_df:
+                call_kwargs["df"] = df
+            if has_ref_df:
+                call_kwargs["ref_df"] = ref_df
             if has_N:
-                call_kwargs = {}
-                if has_df:
-                    call_kwargs["df"] = df
-                if has_ref_df:
-                    call_kwargs["ref_df"] = ref_df
                 call_kwargs["_N"] = _N
-                results[name] = expr_or_func(**call_kwargs)
-            else:
-                results[name] = expr_or_func(df, ref_df)
+            results[name] = expr_or_func(**call_kwargs)
         else:
             # Treat as string expression
             results[name] = eval(

--- a/tests/test_analysis_tree.py
+++ b/tests/test_analysis_tree.py
@@ -345,6 +345,74 @@ def test_scope_cross_eval():
     assert result_func["sum_diff"] == 30  # (60) - (30) = 30
 
 
+def test_scope_cross_eval_single_arg_df_callable():
+    """Regression test for #60: a single-argument `lambda df: ...` callable -
+    valid for analyze_by/scope_eval - must also work in cross_analyze_by,
+    dispatched by parameter name instead of being called positionally with
+    both df and ref_df.
+    """
+    from pyMyriad.utils import scope_cross_eval
+
+    df = pd.DataFrame({"A": [10, 20, 30]})
+    ref_df = pd.DataFrame({"A": [5, 10, 15]})
+
+    result = scope_cross_eval(df=df, ref_df=ref_df, n=lambda df: len(df))
+
+    assert result == {"n": 3}
+
+
+def test_scope_cross_eval_single_arg_ref_df_callable():
+    """A single-argument `lambda ref_df: ...` callable should also be dispatched
+    by name, receiving only ref_df."""
+    from pyMyriad.utils import scope_cross_eval
+
+    df = pd.DataFrame({"A": [10, 20, 30]})
+    ref_df = pd.DataFrame({"A": [5, 10, 15]})
+
+    result = scope_cross_eval(df=df, ref_df=ref_df, ref_n=lambda ref_df: len(ref_df))
+
+    assert result == {"ref_n": 3}
+
+
+def test_scope_cross_eval_unrecognized_signature_raises_clear_typeerror():
+    """A callable that declares none of df/ref_df/_N should raise a clear,
+    actionable TypeError instead of a confusing arity mismatch deep in eval."""
+    from pyMyriad.utils import scope_cross_eval
+
+    df = pd.DataFrame({"A": [10, 20, 30]})
+    ref_df = pd.DataFrame({"A": [5, 10, 15]})
+
+    with pytest.raises(TypeError, match="bad"):
+        scope_cross_eval(df=df, ref_df=ref_df, bad=lambda: 1)
+
+
+def test_cross_analyze_by_mixes_single_and_two_arg_lambdas():
+    """cross_analyze_by should accept a single-arg `lambda df: ...` callable
+    (e.g. a plain count) alongside a two-arg `lambda df, ref_df: ...`
+    comparison callable in the same call, matching analyze_by's flexibility."""
+    df = pd.DataFrame(
+        {
+            "A": [10, 20, 30, 40, 50, 60],
+            "B": [1, 1, 2, 2, 3, 3],
+        }
+    )
+
+    tree = (
+        AnalysisTree()
+        .split_by("df.B")
+        .cross_analyze_by(
+            ref_lvl="1",
+            n=lambda df: len(df),
+            mean_diff=lambda df, ref_df: np.mean(df.A) - np.mean(ref_df.A),
+        )
+    )
+
+    result = tree.run(df, environ={"np": np})
+    result_str = str(result)
+    assert "n: 2" in result_str
+    assert "mean_diff: 20.0" in result_str
+
+
 # --- denom parameter tests ---
 
 


### PR DESCRIPTION
## Summary

- `scope_cross_eval()` (`utils.py`) called every callable that didn't declare `_N` positionally as `expr_or_func(df, ref_df)`, regardless of its actual signature. A single-argument `lambda df: ...` — perfectly valid for `analyze_by`/`scope_eval` — raised a confusing `TypeError: <lambda>() takes 1 positional argument but 2 were given` when reused in `cross_analyze_by`, with no indication of why.
- `scope_cross_eval` now mirrors `analyze_by`'s existing signature-based dispatch: it inspects the callable's declared parameters and passes only `df`/`ref_df`/`_N` (any combination it declares), via keyword arguments. This means `cross_analyze_by` and `analyze_by` callables are now interchangeable for statistics that don't need `ref_df` (e.g. a plain `n=lambda df: len(df)`).
- If a callable declares none of `df`, `ref_df`, `_N`, a clear `TypeError` is raised naming the statistic and showing example valid signatures, instead of a generic arity error surfacing deep in `eval`.
- Updated the `cross_analyze_by` docstrings (both the `AnalysisTree` and `SplitNode` copies) to document the dispatch rules, matching `analyze_by`'s existing docstring style.

## Test plan

- [x] `uv run pytest tests/ -q` — 145 passed
- [x] New unit tests in `tests/test_analysis_tree.py`: single-arg `df`-only and `ref_df`-only dispatch, the new `TypeError` for an unrecognized signature, and a `cross_analyze_by` integration test mixing a single-arg and two-arg lambda in the same call
- [x] Manually reproduced the original bug (`n=lambda df: len(df)` inside `cross_analyze_by`) and confirmed it now runs correctly
- [x] `uv run ruff check` / `ruff format --check` clean

Closes #60.