### PR TITLE
fix: preserve categorical/ordered dtype through pivoting and row ordering

### DIFF
--- a/src/pyMyriad/listing.py
+++ b/src/pyMyriad/listing.py
@@ -72,6 +72,21 @@ def _merge_path_into_string(df, path_col: str = "path") -> pd.DataFrame:
     return df
 
 
+def _ordered_categorical(series: pd.Series) -> pd.Categorical:
+    """Convert a string series to an ordered Categorical preserving first-appearance order.
+
+    The long-form rows produced by ``flatten()`` already appear in the order
+    the originating split produced them in (the category order for a
+    ``pd.Categorical`` split column, or kwarg order for multi-expression
+    splits) because that order is preserved through dict insertion order in
+    the result tree. ``pivot_table()``/``pivot()`` however sort their result
+    by the plain string value of the grouping columns, discarding that order.
+    Recording it as Categorical categories makes pivoting respect it instead.
+    """
+    categories = pd.unique(series)
+    return pd.Categorical(series, categories=categories, ordered=True)
+
+
 def _split_path_into_levels(
     df: pd.DataFrame, path_col: str = "path"
 ) -> tuple[pd.DataFrame, list]:
@@ -215,6 +230,12 @@ def _create_table(
         )
     )
 
+    # Preserve the originating split's row order (categorical dtype order, or
+    # kwarg order for multi-expression splits) instead of letting pivot_table
+    # re-sort rows/columns alphabetically.
+    df["path_pivot"] = _ordered_categorical(df["path_pivot"])
+    df["pivot_lvl"] = _ordered_categorical(df["pivot_lvl"])
+
     # Handle pivot columns if present
     pivot_columns = []
 
@@ -226,6 +247,7 @@ def _create_table(
             columns=["pivot_lvl", "statistics"],
             values="values",
             aggfunc="first",
+            observed=True,
         ).reset_index()
 
         # Flatten the MultiIndex columns
@@ -255,6 +277,7 @@ def _create_table(
             columns="pivot_lvl",
             values="values",
             aggfunc="first",
+            observed=True,
         ).reset_index()
 
     elif pivot_statistics:
@@ -266,14 +289,17 @@ def _create_table(
             columns="statistics",
             values="values",
             aggfunc="first",
+            observed=True,
         ).reset_index()
     else:
         # No pivoting
         pivot_columns = ["values"]
 
     # Revert joining of path_pivot back to list
-    df["path_pivot"] = df["path_pivot"].apply(
-        lambda x: x.split(" > ") if isinstance(x, str) else []
+    df["path_pivot"] = (
+        df["path_pivot"]
+        .astype(object)
+        .apply(lambda x: x.split(" > ") if isinstance(x, str) else [])
     )
 
     # Split path into level columns if requested
@@ -425,12 +451,17 @@ def _create_cascade_table(
         # Conver pivot_lvl to string for pivoting
         df["pivot_lvl"] = _merge_path_into_string(df, path_col="pivot_lvl")["pivot_lvl"]
 
+        # Preserve the originating split's order (categorical dtype order, or
+        # kwarg order) instead of letting pivot_table sort columns alphabetically.
+        df["pivot_lvl"] = _ordered_categorical(df["pivot_lvl"])
+
         df_pivot = df.pivot_table(
             index=["path_pivot", "label", "statistics"],
             columns="pivot_lvl",
             values="values",
             aggfunc="first",
             dropna=True,  # this will drop non-analysis rows. We will merge them back later to keep them in the final table.
+            observed=True,
         ).reset_index()
 
         # select unique path_pivot values to keep non analysis values and merge back the analysis values.
@@ -503,12 +534,17 @@ def _create_cascade_table(
         # Conver pivot_lvl to string for pivoting
         df["pivot_lvl"] = _merge_path_into_string(df, path_col="pivot_lvl")["pivot_lvl"]
 
+        # Preserve the originating split's order (categorical dtype order, or
+        # kwarg order) instead of letting pivot_table sort columns alphabetically.
+        df["pivot_lvl"] = _ordered_categorical(df["pivot_lvl"])
+
         df_pivot = df.pivot_table(
             index=["path_pivot", "label"],
             columns=["pivot_lvl", "statistics"],
             values="values",
             aggfunc="first",
             dropna=True,  # this will drop non-analysis rows. We will merge them back later to keep them in the final table.
+            observed=True,
         ).reset_index()
 
         # select unique path_pivot values to keep non analysis values and merge back the analysis values.

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -522,5 +522,138 @@ def test_simple_table_by_does_not_substring_match_split_label():
         cascade_table(dtree, by="df.ARM")
 
 
+def test_simple_table_pivot_columns_preserve_categorical_order():
+    """Regression test for #61: pivoted columns follow category order, not alphabetical.
+
+    "Week 12" sorts before "Week 4" and "Week 8" alphabetically, so a plain
+    string sort would scramble visit chronology. The split column's ordered
+    Categorical dtype should be respected instead.
+    """
+    df = pd.DataFrame(
+        {
+            "AVISIT": pd.Categorical(
+                ["Week 4", "Baseline", "Week 12", "Week 8"] * 5,
+                categories=["Baseline", "Week 4", "Week 8", "Week 12"],
+                ordered=True,
+            ),
+            "Val": np.arange(20.0),
+        }
+    )
+    atree = (
+        AnalysisTree().split_by("df.AVISIT").analyze_by(mean=lambda df: np.mean(df.Val))
+    )
+    dtree = atree.run(df)
+
+    result = simple_table(dtree, by="df.AVISIT")
+    assert list(result.columns) == [
+        "Statistic",
+        "Baseline",
+        "Week 4",
+        "Week 8",
+        "Week 12",
+    ]
+
+
+def test_simple_table_pivot_statistics_columns_preserve_categorical_order():
+    """Regression test for #61: same ordering guarantee with pivot_statistics=True."""
+    df = pd.DataFrame(
+        {
+            "AVISIT": pd.Categorical(
+                ["Week 4", "Baseline", "Week 12", "Week 8"] * 5,
+                categories=["Baseline", "Week 4", "Week 8", "Week 12"],
+                ordered=True,
+            ),
+            "Val": np.arange(20.0),
+        }
+    )
+    atree = (
+        AnalysisTree().split_by("df.AVISIT").analyze_by(mean=lambda df: np.mean(df.Val))
+    )
+    dtree = atree.run(df)
+
+    result = simple_table(dtree, by="df.AVISIT", pivot_statistics=True)
+    assert list(result.columns) == [
+        "Baseline||mean",
+        "Week 4||mean",
+        "Week 8||mean",
+        "Week 12||mean",
+    ]
+
+
+def test_cascade_table_pivot_columns_preserve_categorical_order():
+    """Regression test for #61: cascade_table column order also follows category order."""
+    df = pd.DataFrame(
+        {
+            "AVISIT": pd.Categorical(
+                ["Week 4", "Baseline", "Week 12", "Week 8"] * 5,
+                categories=["Baseline", "Week 4", "Week 8", "Week 12"],
+                ordered=True,
+            ),
+            "Val": np.arange(20.0),
+        }
+    )
+    atree = (
+        AnalysisTree().split_by("df.AVISIT").analyze_by(mean=lambda df: np.mean(df.Val))
+    )
+    dtree = atree.run(df)
+
+    result = cascade_table(dtree, by="df.AVISIT")
+    pivoted_cols = [c for c in result.columns if c not in ("_Level_0", "statistics")]
+    assert pivoted_cols == ["Baseline", "Week 4", "Week 8", "Week 12"]
+
+    result_stats = cascade_table(dtree, by="df.AVISIT", pivot_statistics=True)
+    assert list(result_stats.columns) == [
+        "Baseline||mean",
+        "Week 4||mean",
+        "Week 8||mean",
+        "Week 12||mean",
+    ]
+
+
+def test_simple_table_row_order_preserves_categorical_order_for_unpivoted_split():
+    """Regression test for #61: a non-pivoted categorical split keeps its row order.
+
+    Mirrors the real-world pattern in examples/lab_change_from_baseline_table_v2.py:
+    Visit is split first (and not pivoted), Arm is split second and pivoted -
+    the Visit row order used to require a hand-written sort_values(key=...).
+    """
+    df = pd.DataFrame(
+        {
+            "AVISIT": pd.Categorical(
+                ["Week 4", "Baseline", "Week 12", "Week 8"] * 5,
+                categories=["Baseline", "Week 4", "Week 8", "Week 12"],
+                ordered=True,
+            ),
+            "ARM": ["A", "B"] * 10,
+            "Val": np.arange(20.0),
+        }
+    )
+    atree = (
+        AnalysisTree()
+        .split_by("df.AVISIT", label="Visit")
+        .split_by("df.ARM", label="Arm")
+        .analyze_by(mean=lambda df: np.mean(df.Val))
+    )
+    dtree = atree.run(df)
+
+    result = simple_table(dtree, by="Arm")
+    visits = result["_Level_1"].tolist()
+    assert visits == ["Baseline", "Week 4", "Week 8", "Week 12"]
+
+
+def test_simple_table_non_categorical_split_remains_alphabetical():
+    """Non-categorical splits have no inherent order, so alphabetical stays the default."""
+    df = pd.DataFrame(
+        {"Group": ["Zebra", "Apple", "Mango"] * 5, "Val": np.arange(15.0)}
+    )
+    atree = (
+        AnalysisTree().split_by("df.Group").analyze_by(mean=lambda df: np.mean(df.Val))
+    )
+    dtree = atree.run(df)
+
+    result = simple_table(dtree, by="df.Group")
+    assert list(result.columns) == ["Statistic", "Apple", "Mango", "Zebra"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- `simple_table()`/`cascade_table()`'s `pivot_table()` calls previously sorted rows/columns alphabetically once split levels were joined into plain strings, discarding any `pd.Categorical(..., ordered=True)` order from the originating split column (e.g. "Baseline, Week 12, Week 4, Week 8" instead of chronological visit order).
- The result tree already preserves the right order through dict insertion order (categorical groupby order, or kwarg order for multi-expression splits) — the bug was purely in the pivot/display layer in `listing.py`.
- Added `_ordered_categorical()`, which tags the joined `pivot_lvl`/`path_pivot` columns as an ordered `Categorical` (first-appearance order) right before each `pivot_table()` call, with `observed=True` so pandas' groupby respects that order instead of falling back to a string sort. Non-categorical splits are unaffected since their first-appearance order already coincides with alphabetical order.

Fixes #61

## Test plan
- [x] `uv run pytest tests/` — 150 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] Manually verified `simple_table`/`cascade_table`/`gt_table` with `by=`, `pivot_statistics=True`, and non-pivoted row hierarchies against an ordered-categorical `AVISIT` column (mirrors `examples/lab_change_from_baseline_table_v2.py`'s pattern) — visit order now comes out correct without the hand-written `sort_values(key=...)` workaround
- [x] Verified non-categorical splits still default to alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)