### PR TITLE
fix: preserve analyze_by/format_statistics statistic order in pivot tables

### DIFF
--- a/src/pyMyriad/listing.py
+++ b/src/pyMyriad/listing.py
@@ -232,9 +232,12 @@ def _create_table(
 
     # Preserve the originating split's row order (categorical dtype order, or
     # kwarg order for multi-expression splits) instead of letting pivot_table
-    # re-sort rows/columns alphabetically.
+    # re-sort rows/columns alphabetically.  The same treatment is applied to
+    # the statistics dimension so that analyze_by() / format_statistics() kwarg
+    # order is respected in the final table rather than sorted alphabetically.
     df["path_pivot"] = _ordered_categorical(df["path_pivot"])
     df["pivot_lvl"] = _ordered_categorical(df["pivot_lvl"])
+    df["statistics"] = _ordered_categorical(df["statistics"])
 
     # When "Analysis" is pivoted into columns, the label column must be dropped
     # from the pivot index so that rows with the same statistics but different

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -655,6 +655,68 @@ def test_simple_table_non_categorical_split_remains_alphabetical():
     assert list(result.columns) == ["Statistic", "Apple", "Mango", "Zebra"]
 
 
+def test_simple_table_statistic_rows_follow_analyze_by_order():
+    """Regression test for #72: Statistic rows preserve analyze_by() kwarg order."""
+    df = pd.DataFrame({"G": ["A", "B"], "V": [1.0, 2.0]})
+    atree = (
+        AnalysisTree()
+        .split_by("df.G", label="Group")
+        .analyze_by(zzz_last=lambda df: 0, aaa_first=lambda df: 1, mmm_mid=lambda df: 2)
+    )
+    dtree = atree.run(df)
+
+    result = simple_table(dtree, by="Group")
+    assert result["Statistic"].tolist() == ["zzz_last", "aaa_first", "mmm_mid"]
+
+
+def test_simple_table_pivot_statistics_columns_follow_analyze_by_order():
+    """Regression test for #72: with pivot_statistics=True stats stay in kwarg order."""
+    df = pd.DataFrame({"G": ["A", "B"], "V": [1.0, 2.0]})
+    atree = (
+        AnalysisTree()
+        .split_by("df.G", label="Group")
+        .analyze_by(zzz_last=lambda df: 0, aaa_first=lambda df: 1, mmm_mid=lambda df: 2)
+    )
+    dtree = atree.run(df)
+
+    result = simple_table(dtree, by="Group", pivot_statistics=True)
+    # Statistic order within each group should follow analyze_by kwarg order.
+    assert list(result.columns) == [
+        "A||zzz_last",
+        "A||aaa_first",
+        "A||mmm_mid",
+        "B||zzz_last",
+        "B||aaa_first",
+        "B||mmm_mid",
+    ]
+
+
+def test_simple_table_statistic_rows_follow_format_statistics_order():
+    """Regression test for #72: format_statistics kwarg order is respected in the table."""
+    df = pd.DataFrame({"G": ["A", "A", "B", "B"], "V": [1.0, 2.0, 3.0, 4.0]})
+    atree = (
+        AnalysisTree()
+        .split_by("df.G", label="Group")
+        .analyze_by(
+            n=lambda df: len(df),
+            mean=lambda df: np.mean(df.V),
+            sd=lambda df: np.std(df.V, ddof=1),
+        )
+    )
+    dtree = atree.run(df)
+    from pyMyriad import format_statistics
+
+    formatted = format_statistics(
+        dtree,
+        n="[{n}]",
+        mean_sd="{mean:.1f} ({sd:.2f})",
+        remove_original=True,
+    )
+
+    result = simple_table(formatted, by="Group")
+    assert result["Statistic"].tolist() == ["n", "mean_sd"]
+
+
 def test_simple_table_by_analysis_produces_label_pivot_columns():
     """Regression test for #70: by='Analysis' turns analyze_by() labels into columns."""
     df = pd.DataFrame({"G": ["M", "M", "F", "F"], "V": [1.0, 2.0, 3.0, 4.0]})


### PR DESCRIPTION
## Summary
- `simple_table(by=X)` was sorting the `Statistic` rows alphabetically instead of following the order statistics were defined in `analyze_by()` or `format_statistics()`.
- `simple_table(by=X, pivot_statistics=True)` had the same issue within each group's `||stat` column sequence.
- One-line fix: apply `_ordered_categorical(df["statistics"])` in `_create_table()` alongside the existing `path_pivot` and `pivot_lvl` calls added in #68. The data was already in the right order before the pivot — `pivot_table()` was the sole source of the alphabetical re-sort.

## What was happening
`flatten()` unnests `DataNode.summary` using `dict.keys()` / `dict.values()`, which preserve insertion order (Python 3.7+), so statistics arrive in the flattened DataFrame in definition order. `_ordered_categorical` on `path_pivot`/`pivot_lvl` was already preserving split-level order, but `statistics` was never given the same treatment — leaving `pivot_table()`'s internal groupby to sort it alphabetically.

## After the fix
Statistic order now falls naturally out of:
- `analyze_by()` kwarg order for raw statistics
- `format_statistics()` kwarg order for combined/formatted statistics (the primary motivating use case: `n`, `mean_sd`, `mqq`, `min_max` in the order written, not alphabetical)

## Test plan
- [x] `uv run pytest tests/` — 160 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] 3 new regression tests in `test_listing.py` covering `analyze_by` order, `pivot_statistics=True` order, and `format_statistics` order

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)